### PR TITLE
Fix encoding for radiances in debug version.

### DIFF
--- a/FCDR_HIRS/_fcdr_defs.py
+++ b/FCDR_HIRS/_fcdr_defs.py
@@ -15,8 +15,8 @@ _debug_bt_coding["dtype"] = "u4"
 _debug_bt_coding["scale_factor"] /= 10
 
 _debug_Re_coding = _coding.copy()
-_debug_Re_coding["dtype"] = "u4"
-_debug_Re_coding["scale_factor"] = 0.0001
+_debug_Re_coding["dtype"] = "u8"
+_debug_Re_coding["scale_factor"] = 1e-21 # mW units...
 _debug_Re_coding["_FillValue"] = _u2_coding["_FillValue"]
 
 _u_count_coding = _count_coding.copy()

--- a/FCDR_HIRS/processing/generate_fcdr.py
+++ b/FCDR_HIRS/processing/generate_fcdr.py
@@ -84,7 +84,10 @@ Changed approach to flags:
 
 Overlap between subsequent granules are now selected based on "best
 scanline" criterion, rather than always the oldest (GH#7).
+
 Add missing months January-February 1985 for NOAA-7 (reported by MS).
+
+Fix encoding for radiances in debug version.
 
 """
 


### PR DESCRIPTION
Debug version had zero radiance due to incorrect scale factor.
This commit fixes #186.