### PR TITLE
R_lΛes shan't fail on ultra-short orbits

### DIFF
--- a/FCDR_HIRS/effects.py
+++ b/FCDR_HIRS/effects.py
@@ -238,7 +238,10 @@ class RModelRSelf(Rmodel):
         i = itertools.count()
         while True:
             d = next(i)
-            r = 1 - (ds["scanline_earth"][d] - ds["scanline_earth"][0])/numpy.timedelta64(25, 'm')
+            try:
+                r = 1 - (ds["scanline_earth"][d] - ds["scanline_earth"][0])/numpy.timedelta64(25, 'm')
+            except IndexError: # not enough lines in orbit
+                break
             if r <= 0:
                 break
             for s in (+1, -1):

--- a/setup.py
+++ b/setup.py
@@ -31,8 +31,8 @@ cp = subprocess.run(
     check=True)
 br = cp.stdout
 
-version = so.strip().decode("ascii").lstrip("v").replace("-",
-    "+dev", 1).replace("-", ".") + "." + br.strip().decode("ascii")
+version = so.strip().decode("utf-8").lstrip("v").replace("-",
+    "+dev", 1).replace("-", ".") + "." + br.strip().decode("utf-8")
 
 setup(
     name='FCDR_HIRS',


### PR DESCRIPTION
Calculation of R_lΛes for the self-emission model was failing for
ultra-short orbit files, where I could not construct a linear decline from 1 to
0 over ¼ orbit.  Cut this off now.  Correlation length scale may be
incorrect.

Abuse this PR to allow unicode characters in branch names.