### PR TITLE
Fix rare bug in flag setting

### DIFF
--- a/FCDR_HIRS/fcdr.py
+++ b/FCDR_HIRS/fcdr.py
@@ -1330,7 +1330,7 @@ class HIRSFCDR(typhon.datasets.dataset.HomemadeDataset):
             # NB, need to test if this takes care of most remaining
             # bad outliers!  May need an entire rerun of the archive for
             # that...
-            self._flags["pixel"].loc[{"calibrated_channel": ch}].values[bad] |= (
+            self._flags["pixel"].loc[{"calibrated_channel": ch}].values[bad.values] |= (
                 _fcdr_defs.FlagsPixel.DO_NOT_USE|_fcdr_defs.FlagsPixel.OUTLIER_NOS)
             # 
             coords = {"calibration_cycle": time.values}


### PR DESCRIPTION
For some reasons, when there are less scanlines than scan positions, the
flag setting here fails, but it otherwise succeeds.  This does not happen
when passing bad.values, so do that instead.