### PR TITLE
Account for too few but more than 0 scanlines in 6-hour period

### DIFF
--- a/FCDR_HIRS/analysis/logfile_analysis.py
+++ b/FCDR_HIRS/analysis/logfile_analysis.py
@@ -20,6 +20,7 @@ error_modes = dict(
     no_header ="Could not find header",
     non_integer_records = "truncated",
     too_few_scanlines = "File contains only",
+    too_few_scanlines_2 = "scanlines in period",
     firstline_unable = "Unable to filter firstline",
     incomplete_records = "but I found only",
     unsorted_time = "returned data with unsorted time")

--- a/FCDR_HIRS/processing/generate_fcdr.py
+++ b/FCDR_HIRS/processing/generate_fcdr.py
@@ -303,6 +303,12 @@ class FCDRGenerator:
                 f"{from_:%Y-%m-%d %H:%M}--{to:%Y-%m-%d %H:%M}.  NB: "
                 "if this error message happens consistently there is a "
                 "bug!")
+        elif subset.dims["time"] < 3:
+            raise fcdr.FCDRError(f"Found only {subset.dims['time']:d} "
+                "scanlines in period "
+                f"{from_:%Y-%m-%d %H:%M}--{to:%Y-%m-%d %H:%M}.  NB: "
+                "if this error message happens consistently there is a "
+                "bug!")
         context = self.dd.data
 #        if not (context["time"].values[0] < subset["time"].values[0] <
 #                subset["time"].values[-1] < context["time"].values[-1]):


### PR DESCRIPTION
It was crashing when a 6-hour period contained exactly one scanline.  That is doubleplusungood.  Changes such that if there are 1 or 2 it also throws an error and moves on.