### PR TITLE
Add full correlation length vectors to debug FCDR

### DIFF
--- a/FCDR_HIRS/analysis/inspect_orbit_curuc.py
+++ b/FCDR_HIRS/analysis/inspect_orbit_curuc.py
@@ -1,0 +1,31 @@
+"""Plots to test and inspect results of CURUC
+"""
+
+import matplotlib
+import matplotlib.pyplot
+import numpy
+import xarray
+
+import pyatmlab.graphics
+
+def plot_compare_correlation_scanline(ds):
+    ds5 = ds.sel(calibrated_channel=5)
+    y_real = ds5["cross_line_radiance_error_correlation_length_average"]
+    x_real = y_real["delta_scanline_earth"]
+    Δ_l = ds5["cross_line_radiance_error_correlation_length_scale_structured_effects"]
+    y_approx = numpy.exp(-numpy.abs(x_real)/Δ_l)
+
+    (f, a) = matplotlib.pyplot.subplots(figsize=(12, 6))
+    a.plot(x_real, y_real, label="The Real Thing™ (maybe)")
+    a.plot(x_real, y_approx, label="Exponential approximation")
+
+    f.legend()
+    a.set_xlim([0, 500])
+    a.set_xlabel(r"$\Delta$ scanline")
+    a.set_ylabel("Mean correlation coefficient")
+    a.set_title("Mean correlation as function of scanline interval, single orbit")
+
+    pyatmlab.graphics.print_or_show(f, False, "orbit_curuc_test.")
+
+def main():
+    plot_compare_correlation_scanline(xarray.open_dataset("/group_workspaces/cems2/fiduceo/Data/FCDR/HIRS/v0.8pre/debug/metopa/2015/02/01/FIDUCEO_FCDR_L1C_HIRS4_metopa_20150201205557_20150201223710_debug_v0.8pre_fv0.6.nc"))

--- a/FCDR_HIRS/processing/generate_fcdr.py
+++ b/FCDR_HIRS/processing/generate_fcdr.py
@@ -452,9 +452,9 @@ class FCDRGenerator:
         ds["quality_pixel_bitmask"].values[((2*ds["u_R_Earth"]) > ds["R_e"]).transpose(*ds["quality_pixel_bitmask"].dims).values] |= _fcdr_defs.FlagsChannel.UNCERTAINTY_SUSPICIOUS
 
         try:
-            (Δ_l, Δ_e, R_ci, R_cs) = metrology.calc_corr_scale_channel(
+            (Δ_l, Δ_e, R_ci, R_cs, Δ_l_full, Δ_e_full) = metrology.calc_corr_scale_channel(
                 self.fcdr._effects, sensRe, ds, flags=self.fcdr._flags,
-                robust=True)
+                robust=True, return_vectors=True, interpolate_lengths=True)
         except fcdr.FCDRError as e:
             logging.error("Failed to calculate correlation length scales: "
                           f"{e.args[0]}")
@@ -463,9 +463,13 @@ class FCDRGenerator:
             ds["cross_line_radiance_error_correlation_length_scale_structured_effects"] = (("calibrated_channel",), Δ_l.sel(val="popt").values)
             ds["cross_element_radiance_error_correlation_length_scale_structured_effects"] = (("calibrated_channel",), Δ_e.sel(val="popt").values)
             ds["cross_channel_error_correlation_matrix_independent_effects"] = (
-                ("calibration_channel", "calibration_channel"), R_ci)
+                ("calibrated_channel", "calibrated_channel"), R_ci)
             ds["cross_channel_error_correlation_matrix_structured_effects"] = (
-                ("calibration_channel", "calibration_channel"), R_cs)
+                ("calibrated_channel", "calibrated_channel"), R_cs)
+            ds["cross_line_radiance_error_correlation_length_average"] = (
+                ("scanline_earth", "calibrated_channel"), Δ_l_full.values)
+            ds["cross_element_radiance_error_correlation_length_average"] = (
+                ("scanpos", "calibrated_channel"), Δ_e_full.values)
 
         if return_more:
             return (ds, sensRe)

--- a/FCDR_HIRS/processing/generate_fcdr.py
+++ b/FCDR_HIRS/processing/generate_fcdr.py
@@ -467,9 +467,9 @@ class FCDRGenerator:
             ds["cross_channel_error_correlation_matrix_structured_effects"] = (
                 ("calibrated_channel", "calibrated_channel"), R_cs)
             ds["cross_line_radiance_error_correlation_length_average"] = (
-                ("scanline_earth", "calibrated_channel"), Δ_l_full.values)
+                ("delta_scanline_earth", "calibrated_channel"), Δ_l_full.values)
             ds["cross_element_radiance_error_correlation_length_average"] = (
-                ("scanpos", "calibrated_channel"), Δ_e_full.values)
+                ("delta_scanpos", "calibrated_channel"), Δ_e_full.values)
 
         if return_more:
             return (ds, sensRe)

--- a/setup.py
+++ b/setup.py
@@ -157,6 +157,7 @@ setup(
             "write_hirs_harm_meta=FCDR_HIRS.analysis.write_harm_meta:main",
             "merge_hirs_harmonisation=FCDR_HIRS.processing.combine_matchups:merge_files",
             "convert_hirs_harmonisation_parameters=FCDR_HIRS.processing.convert_harm_params:main",
+            "hirs_curuc_checker=FCDR_HIRS.analysis.inspect_orbit_curuc:main",
         ],
     },
 )


### PR DESCRIPTION
This adds full correlationg length vectors to the debug FDCR, and adds the option to return them in `apply_curuc` and related functions.