### PR TITLE
Fix and enhance plotting of long-term trends in FCDR

### DIFF
--- a/FCDR_HIRS/analysis/determine_optimal_uncertainty_format.py
+++ b/FCDR_HIRS/analysis/determine_optimal_uncertainty_format.py
@@ -33,20 +33,20 @@ def main():
         datetime.datetime(2004, 4, 1),
         datetime.datetime(2004, 4, 2),
         locator_args={"data_version": "0.8pre", "fcdr_type": "debug"},
-        fields=("u_T_b_structured", "u_T_b_independent", "T_b"))
+        fields=("u_T_b_nonrandom", "u_T_b_random", "T_b"))
     
     with tempfile.TemporaryDirectory() as td:
         ds = dsref.copy()
         out_as_bt = pathlib.Path(td + "/u_as_bt.nc")
         out_as_perc = pathlib.Path(td + "/u_as_perc.nc")
-        ds["u_T_b_structured"].encoding = codings["as_bt"]
-        ds["u_T_b_independent"].encoding = codings["as_bt"]
+        ds["u_T_b_nonrandom"].encoding = codings["as_bt"]
+        ds["u_T_b_random"].encoding = codings["as_bt"]
         ds.to_netcdf(str(out_as_bt))
         ds = dsref.copy()
-        ds["u_T_b_structured"] /= ds["T_b"]
-        ds["u_T_b_independent"] /= ds["T_b"]
-        ds["u_T_b_structured"].encoding = codings["as_perc"]
-        ds["u_T_b_independent"].encoding = codings["as_perc"]
+        ds["u_T_b_nonrandom"] /= ds["T_b"]
+        ds["u_T_b_random"] /= ds["T_b"]
+        ds["u_T_b_nonrandom"].encoding = codings["as_perc"]
+        ds["u_T_b_random"].encoding = codings["as_perc"]
         ds.to_netcdf(str(out_as_perc))
         print("as bt", out_as_bt.stat().st_size)
         print("as perc", out_as_perc.stat().st_size)

--- a/FCDR_HIRS/analysis/determine_optimal_uncertainty_format.py
+++ b/FCDR_HIRS/analysis/determine_optimal_uncertainty_format.py
@@ -32,21 +32,21 @@ def main():
     dsref = hirs.read_period(
         datetime.datetime(2004, 4, 1),
         datetime.datetime(2004, 4, 2),
-        locator_args={"data_version": "0.5pre", "fcdr_type": "debug"},
-        fields=("u_T_b_nonrandom", "u_T_b_random", "T_b"))
+        locator_args={"data_version": "0.8pre", "fcdr_type": "debug"},
+        fields=("u_T_b_structured", "u_T_b_independent", "T_b"))
     
     with tempfile.TemporaryDirectory() as td:
         ds = dsref.copy()
         out_as_bt = pathlib.Path(td + "/u_as_bt.nc")
         out_as_perc = pathlib.Path(td + "/u_as_perc.nc")
-        ds["u_T_b_nonrandom"].encoding = codings["as_bt"]
-        ds["u_T_b_random"].encoding = codings["as_bt"]
+        ds["u_T_b_structured"].encoding = codings["as_bt"]
+        ds["u_T_b_independent"].encoding = codings["as_bt"]
         ds.to_netcdf(str(out_as_bt))
         ds = dsref.copy()
-        ds["u_T_b_nonrandom"] /= ds["T_b"]
-        ds["u_T_b_random"] /= ds["T_b"]
-        ds["u_T_b_nonrandom"].encoding = codings["as_perc"]
-        ds["u_T_b_random"].encoding = codings["as_perc"]
+        ds["u_T_b_structured"] /= ds["T_b"]
+        ds["u_T_b_independent"] /= ds["T_b"]
+        ds["u_T_b_structured"].encoding = codings["as_perc"]
+        ds["u_T_b_independent"].encoding = codings["as_perc"]
         ds.to_netcdf(str(out_as_perc))
         print("as bt", out_as_bt.stat().st_size)
         print("as perc", out_as_perc.stat().st_size)

--- a/FCDR_HIRS/analysis/map_single_orbit.py
+++ b/FCDR_HIRS/analysis/map_single_orbit.py
@@ -113,10 +113,10 @@ class OrbitPlotter:
             t1 = trans[:, :, 1]
             self._plot_to(ax_all[0], cax_all[0], t0, t1, dsx["bt"].values,
                 "BT [K]")
-            self._plot_to(ax_all[1], cax_all[1], t0, t1, dsx["u_random"].values,
+            self._plot_to(ax_all[1], cax_all[1], t0, t1, dsx["u_independent"].values,
                 "Independent uncertainty [K]",
                 is_uncertainty=True)
-            self._plot_to(ax_all[2], cax_all[2], t0, t1, dsx["u_non_random"].values,
+            self._plot_to(ax_all[2], cax_all[2], t0, t1, dsx["u_structured"].values,
                 "Structured uncertainty [K]",
                 is_uncertainty=True)
         # flags are plotted for all cases, flagged or not
@@ -188,7 +188,7 @@ class OrbitPlotter:
                 joiner=",\n")
 
     def write(self):
-        p = self.path
+        p = self.path.absolute()
         pyatmlab.graphics.print_or_show(
             self.fig, False,
             "orbitplots/"

--- a/FCDR_HIRS/analysis/monitor_fcdr.py
+++ b/FCDR_HIRS/analysis/monitor_fcdr.py
@@ -77,7 +77,7 @@ class FCDRMonitor:
     def plot_timeseries(self, ch, sp=28):
         counter = itertools.count()
         ds = self.ds.sel(calibrated_channel=ch, scanpos=sp, minor_frame=sp)
-        nrow = 7
+        nrow = 8
         gs = matplotlib.gridspec.GridSpec(nrow, 4)
         fig = matplotlib.pyplot.figure(figsize=(18, 3*nrow))
 #        (fig, axes) = matplotlib.pyplot.subplots(nrow, 2,
@@ -132,8 +132,10 @@ class FCDRMonitor:
         c = next(counter)
         # although exact same width as other time series would be
         # desirable, the colourbar currently messes this up /anyway/, so
-        # we might as well take the full width
-        a_flags = fig.add_subplot(gs[c, :])
+        # we might as well take the full width.  Use double height,
+        # because there are many flags and each should be readable
+        # individually.
+        a_flags = fig.add_subplot(gs[c:c+2, :])
         perc_all = []
         labels = []
         period = ("5min" if
@@ -161,6 +163,7 @@ class FCDRMonitor:
 
 #        a_tb_u_h = fig.add_subplot(gs[c, 3])
 
+        next(counter)
         c = next(counter)
         a_L = fig.add_subplot(gs[c, :3])
         a_L_h = fig.add_subplot(gs[c, 3])

--- a/FCDR_HIRS/analysis/monitor_fcdr.py
+++ b/FCDR_HIRS/analysis/monitor_fcdr.py
@@ -55,7 +55,7 @@ class FCDRMonitor:
               "{tb:%Y-%m-%d %H:%M}--{te:%Y-%m-%d %H:%M} (scanpos {sp:d})")
     fields=["T_b", "u_T_b_random", "u_T_b_nonrandom",
         "R_e", "u_R_Earth_random", "u_R_Earth_nonrandom",
-        'u_from_R_selfE', 'u_from_a_0', 'u_from_a_2', 'u_from_a_1',
+        'u_from_R_selfE', 'u_from_a_2', 
         'u_from_C_s', 'u_from_C_IWCT', 'u_from_R_IWCT', 'u_from_B',
         'u_from_Tstar', 'u_from_β', 'u_from_α', 'u_from_T_IWCT',
         'u_from_O_TIWCT', 'u_from_fstar', 'u_from_R_refl', 'u_from_C_E',

--- a/FCDR_HIRS/analysis/monitor_fcdr.py
+++ b/FCDR_HIRS/analysis/monitor_fcdr.py
@@ -53,8 +53,8 @@ class FCDRMonitor:
                "-{te:%Y%m%d%H%M}.png")
     figtit = ("HIRS FCDR v{self.version:s} with uncertainties {self.satname:s} ch. {ch:d}, "
               "{tb:%Y-%m-%d %H:%M}--{te:%Y-%m-%d %H:%M} (scanpos {sp:d})")
-    fields=["T_b", "u_T_b_random", "u_T_b_nonrandom",
-        "R_e", "u_R_Earth_random", "u_R_Earth_nonrandom",
+    fields=["T_b", "u_T_b_independent", "u_T_b_structured",
+        "R_e", "u_R_Earth_independent", "u_R_Earth_structured",
         'u_from_R_selfE', 'u_from_a_0', 'u_from_a_2', 'u_from_a_1',
         'u_from_C_s', 'u_from_C_IWCT', 'u_from_R_IWCT', 'u_from_B',
         'u_from_Tstar', 'u_from_β', 'u_from_α', 'u_from_T_IWCT',
@@ -84,7 +84,7 @@ class FCDRMonitor:
 #            gridspec_kw={"width_ratios": [3, 1], "hspace": 1},
 #            figsize=(18, 3*nrow))
 
-#        bad = (2*ds["u_R_Earth_nonrandom"] > ds["R_e"])
+#        bad = (2*ds["u_R_Earth_structured"] > ds["R_e"])
 #        for v in self.fields:
 #            ds[v][bad] = numpy.nan 
 
@@ -113,7 +113,7 @@ class FCDRMonitor:
             )!=0
         
         # This doesn't work
-        # ds[["T_b","u_T_b_random","u_T_b_nonrandom"]][{"scanline_earth": bad}] = numpy.nan
+        # ds[["T_b","u_T_b_independent","u_T_b_structured"]][{"scanline_earth": bad}] = numpy.nan
         for fld in {f for f in self.fields
                     if f.startswith("u_")
                     or f in {"T_b", "R_e"}}:
@@ -121,8 +121,8 @@ class FCDRMonitor:
 
         self._plot_var_with_unc(
             ds["T_b"],
-            ds["u_T_b_random"],
-            ds["u_T_b_nonrandom"],
+            ds["u_T_b_independent"],
+            ds["u_T_b_structured"],
             a_tb, a_tb_h, a_tb_u, a_tb_u_h)
 
         dsu = ds[[x for x in ds.data_vars.keys() if x.startswith("u_from_")]]
@@ -171,26 +171,26 @@ class FCDRMonitor:
 
         self._plot_var_with_unc(
             UADA(ds["R_e"]).to(rad_u["ir"], "radiance"),
-            UADA(ds["u_R_Earth_random"]).to(rad_u["ir"], "radiance"),
-            UADA(ds["u_R_Earth_nonrandom"]).to(rad_u["ir"], "radiance"),
+            UADA(ds["u_R_Earth_independent"]).to(rad_u["ir"], "radiance"),
+            UADA(ds["u_R_Earth_structured"]).to(rad_u["ir"], "radiance"),
             a_L, a_L_h, a_L_u, a_L_u_h)
 
         c = next(counter)
         gridsize = 50
         cmap = "viridis"
         self._plot_hexbin(
-            ds["T_b"], ds["u_T_b_random"],
+            ds["T_b"], ds["u_T_b_independent"],
             fig.add_subplot(gs[c, 0]))
         self._plot_hexbin(
-            ds["T_b"], ds["u_T_b_nonrandom"],
+            ds["T_b"], ds["u_T_b_structured"],
             fig.add_subplot(gs[c, 1]))
         self._plot_hexbin(
             UADA(ds["R_e"]).to(rad_u["ir"], "radiance"),
-            UADA(ds["u_R_Earth_random"]).to(rad_u["ir"], "radiance"),
+            UADA(ds["u_R_Earth_independent"]).to(rad_u["ir"], "radiance"),
             fig.add_subplot(gs[c, 2]))
         hb = self._plot_hexbin(
             UADA(ds["R_e"]).to(rad_u["ir"], "radiance"),
-            UADA(ds["u_R_Earth_nonrandom"]).to(rad_u["ir"], "radiance"),
+            UADA(ds["u_R_Earth_structured"]).to(rad_u["ir"], "radiance"),
             fig.add_subplot(gs[c, 3]))
         # todo: colorbar
 

--- a/FCDR_HIRS/analysis/monitor_fcdr.py
+++ b/FCDR_HIRS/analysis/monitor_fcdr.py
@@ -53,8 +53,8 @@ class FCDRMonitor:
                "-{te:%Y%m%d%H%M}.png")
     figtit = ("HIRS FCDR v{self.version:s} with uncertainties {self.satname:s} ch. {ch:d}, "
               "{tb:%Y-%m-%d %H:%M}--{te:%Y-%m-%d %H:%M} (scanpos {sp:d})")
-    fields=["T_b", "u_T_b_independent", "u_T_b_structured",
-        "R_e", "u_R_Earth_independent", "u_R_Earth_structured",
+    fields=["T_b", "u_T_b_random", "u_T_b_nonrandom",
+        "R_e", "u_R_Earth_random", "u_R_Earth_nonrandom",
         'u_from_R_selfE', 'u_from_a_0', 'u_from_a_2', 'u_from_a_1',
         'u_from_C_s', 'u_from_C_IWCT', 'u_from_R_IWCT', 'u_from_B',
         'u_from_Tstar', 'u_from_β', 'u_from_α', 'u_from_T_IWCT',
@@ -84,7 +84,7 @@ class FCDRMonitor:
 #            gridspec_kw={"width_ratios": [3, 1], "hspace": 1},
 #            figsize=(18, 3*nrow))
 
-#        bad = (2*ds["u_R_Earth_structured"] > ds["R_e"])
+#        bad = (2*ds["u_R_Earth_nonrandom"] > ds["R_e"])
 #        for v in self.fields:
 #            ds[v][bad] = numpy.nan 
 
@@ -113,7 +113,7 @@ class FCDRMonitor:
             )!=0
         
         # This doesn't work
-        # ds[["T_b","u_T_b_independent","u_T_b_structured"]][{"scanline_earth": bad}] = numpy.nan
+        # ds[["T_b","u_T_b_random","u_T_b_nonrandom"]][{"scanline_earth": bad}] = numpy.nan
         for fld in {f for f in self.fields
                     if f.startswith("u_")
                     or f in {"T_b", "R_e"}}:
@@ -121,8 +121,8 @@ class FCDRMonitor:
 
         self._plot_var_with_unc(
             ds["T_b"],
-            ds["u_T_b_independent"],
-            ds["u_T_b_structured"],
+            ds["u_T_b_random"],
+            ds["u_T_b_nonrandom"],
             a_tb, a_tb_h, a_tb_u, a_tb_u_h)
 
         dsu = ds[[x for x in ds.data_vars.keys() if x.startswith("u_from_")]]
@@ -171,26 +171,26 @@ class FCDRMonitor:
 
         self._plot_var_with_unc(
             UADA(ds["R_e"]).to(rad_u["ir"], "radiance"),
-            UADA(ds["u_R_Earth_independent"]).to(rad_u["ir"], "radiance"),
-            UADA(ds["u_R_Earth_structured"]).to(rad_u["ir"], "radiance"),
+            UADA(ds["u_R_Earth_random"]).to(rad_u["ir"], "radiance"),
+            UADA(ds["u_R_Earth_nonrandom"]).to(rad_u["ir"], "radiance"),
             a_L, a_L_h, a_L_u, a_L_u_h)
 
         c = next(counter)
         gridsize = 50
         cmap = "viridis"
         self._plot_hexbin(
-            ds["T_b"], ds["u_T_b_independent"],
+            ds["T_b"], ds["u_T_b_random"],
             fig.add_subplot(gs[c, 0]))
         self._plot_hexbin(
-            ds["T_b"], ds["u_T_b_structured"],
+            ds["T_b"], ds["u_T_b_nonrandom"],
             fig.add_subplot(gs[c, 1]))
         self._plot_hexbin(
             UADA(ds["R_e"]).to(rad_u["ir"], "radiance"),
-            UADA(ds["u_R_Earth_independent"]).to(rad_u["ir"], "radiance"),
+            UADA(ds["u_R_Earth_random"]).to(rad_u["ir"], "radiance"),
             fig.add_subplot(gs[c, 2]))
         hb = self._plot_hexbin(
             UADA(ds["R_e"]).to(rad_u["ir"], "radiance"),
-            UADA(ds["u_R_Earth_structured"]).to(rad_u["ir"], "radiance"),
+            UADA(ds["u_R_Earth_nonrandom"]).to(rad_u["ir"], "radiance"),
             fig.add_subplot(gs[c, 3]))
         # todo: colorbar
 

--- a/FCDR_HIRS/analysis/summarise_fcdr.py
+++ b/FCDR_HIRS/analysis/summarise_fcdr.py
@@ -30,7 +30,7 @@ def parse_cmdline():
              "hardcoded by type.")
 
     parser.add_argument("--version", action="store", type=str,
-        default="0.7",
+        default="0.8pre",
         help="Version to use.")
 #            "or plot from them")
 
@@ -111,8 +111,8 @@ class FCDRSummary(HomemadeDataset):
 
     fields = {
         "debug":
-            ["T_b", "u_T_b_random", "u_T_b_nonrandom",
-            "R_e", "u_R_Earth_random", "u_R_Earth_nonrandom",
+            ["T_b", "u_T_b_independent", "u_T_b_structured",
+            "R_e", "u_R_Earth_independent", "u_R_Earth_structured",
             "u_C_Earth"],
         "easy":
             ["bt", "u_independent", "u_structured"],
@@ -122,11 +122,11 @@ class FCDRSummary(HomemadeDataset):
         {
         **{field: (("edges",), [170, 320]) for field in ("T_b", "bt")},
         **{field: (("edges",), [0, 200]) for field in 
-            ["u_T_b_random", "u_T_b_nonrandom",
+            ["u_T_b_independent", "u_T_b_structured",
              "u_independent", "u_structured"]},
         **{field: (("channel", "edges"),
                    [[0, 200]]*10+[[0, 100]]*2+[[0,10]]*7)
-            for field in ("R_e", "u_R_Earth_random", "u_R_Earth_nonrandom")},
+            for field in ("R_e", "u_R_Earth_independent", "u_R_Earth_structured")},
         "u_C_Earth": (("edges",), [-4097, 4098]),
         },
         coords={"channel": numpy.arange(1, 20)})
@@ -199,7 +199,7 @@ class FCDRSummary(HomemadeDataset):
             except DataFileError:
                 continue
             if fcdr_type == "debug":
-                bad = (2*ds["u_R_Earth_nonrandom"] > ds["R_e"])
+                bad = (2*ds["u_R_Earth_structured"] > ds["R_e"])
             else: # should be "easy"
                 bad = (2*ds["u_structured"] > ds["bt"])
             for field in fields[fcdr_type]:
@@ -278,9 +278,9 @@ class FCDRSummary(HomemadeDataset):
         summary = self.read_period(start, end,
             locator_args={"data_version": "v"+self.data_version,
                 "fcdr_type": fcdr_type})
-        #fields = ["T_b", "u_T_b_random", "u_T_b_nonrandom"]
+        #fields = ["T_b", "u_T_b_independent", "u_T_b_structured"]
 
-#        for field in ("u_T_b_random", "u_R_Earth_random", "u_C_Earth"):
+#        for field in ("u_T_b_independent", "u_R_Earth_independent", "u_C_Earth"):
 #            summary[field] *= numpy.sqrt(48) # workaround #125, remove after fix
         for channel in range(1, 20):
             total_title = (f"HIRS {self.satname:s} ch {channel:d} "

--- a/FCDR_HIRS/analysis/summarise_fcdr.py
+++ b/FCDR_HIRS/analysis/summarise_fcdr.py
@@ -417,7 +417,8 @@ class FCDRSummary(HomemadeDataset):
             pyatmlab.graphics.print_or_show(f, None, 
                 self.plot_file.format(satname=satlabel, start=start,
                     end=end, channel=channel,
-                    data_version=self.data_version)[:-1] + "_zoom.")
+                    data_version=self.data_version,
+                    ptilestr=','.join(str(p) for p in ptiles))[:-1] + "_zoom.")
         self.satname = oldsatname
 
 

--- a/FCDR_HIRS/analysis/summarise_fcdr.py
+++ b/FCDR_HIRS/analysis/summarise_fcdr.py
@@ -312,7 +312,7 @@ class FCDRSummary(HomemadeDataset):
                 nrows=len(fields), ncols=1, squeeze=False)
                 
         ranges = xarray.DataArray(
-            numpy.zeros((len(sats), 19, len(fields), 2), dtype="f4"),
+            numpy.full((len(sats), 19, len(fields), 2), numpy.nan, dtype="f4"),
             dims=("satname", "channel", "field", "extremum"),
             coords={"satname": sats, "channel": range(1, 20),
                 "field": fields,

--- a/FCDR_HIRS/analysis/summarise_fcdr.py
+++ b/FCDR_HIRS/analysis/summarise_fcdr.py
@@ -338,6 +338,8 @@ class FCDRSummary(HomemadeDataset):
                         "fcdr_type": fcdr_type,
                         "satname": sat},
                     NO_CACHE=True)
+                if all(summary.isnull().all()[fields].all().variables.values()):
+                    raise DataFileError(f"All data invalid for {sat:s}!")
             except DataFileError:
                 continue
             else:

--- a/FCDR_HIRS/analysis/summarise_fcdr.py
+++ b/FCDR_HIRS/analysis/summarise_fcdr.py
@@ -214,12 +214,12 @@ class FCDRSummary(HomemadeDataset):
                 continue
             if fcdr_type == "debug":
                 bad = ((2*ds["u_R_Earth_nonrandom"] > ds["R_e"]) |
-                        (ds["quality_scanline_bitmask"] & 1) |
-                        (ds["quality_channel_bitmask"] & 1))
+                        ((ds["quality_scanline_bitmask"] & 1)!=0) |
+                        ((ds["quality_channel_bitmask"] & 1)!=0))
             else: # should be "easy"
                 bad = ((2*ds["u_structured"] > ds["bt"]) |
-                       (ds["quality_scanline_bitmask"].astype("uint8") & 1) |
-                       (ds["quality_channel_bitmask"].astype("uint8") & 1))
+                       ((ds["quality_scanline_bitmask"].astype("uint8") & 1)!=0) |
+                       ((ds["quality_channel_bitmask"].astype("uint8") & 1)!=0))
             for field in fields[fcdr_type]:
                 if field != "u_C_Earth":
                     # workaround for https://github.com/FIDUCEO/FCDR_HIRS/issues/152
@@ -231,6 +231,9 @@ class FCDRSummary(HomemadeDataset):
                     da = ds[field]
                 if not da.notnull().any():
                     # hopeless
+                    logging.warning(f"All bad data for {self.satname:s} "
+                        f"{sd.year:d}-{sd.month:d}-{sd.day:d}–{ed.year:d}-{ed.month:d}-{ed.day}, not "
+                        f"summarising {field:s}.")
                     continue
                 # cannot apply limits here https://github.com/scipy/scipy/issues/7342
                 # and need to mask nans, see

--- a/FCDR_HIRS/analysis/summarise_fcdr.py
+++ b/FCDR_HIRS/analysis/summarise_fcdr.py
@@ -391,7 +391,7 @@ def summarise():
     elif p.mode == "plot":
 #        sumdat = summary.plot_period(start, end, 5, fields=["u_C_Earth"],
 #            ptiles=[50], pstyles=["-"], fcdr_type=p.type)
-        summary.plot_period_hists(start, end, "easy")
+        summary.plot_period_hists(start, end, p.type)
 #            fields=["bt", "u_independent", "u_structured"],
 #            fcdr_type="easy")
         summary.plot_period_ptiles(start, end,

--- a/FCDR_HIRS/analysis/summarise_fcdr.py
+++ b/FCDR_HIRS/analysis/summarise_fcdr.py
@@ -381,7 +381,7 @@ class FCDRSummary(HomemadeDataset):
                         a.set_ylabel(labels[fld])
                     if i==0 and (len(ptiles)>1 or len(sats)>1):
                         a.legend(loc="upper left", bbox_to_anchor=(1, 1))
-                    a.grid(axis="both")
+                    a.grid(True, axis="both")
                 # prepare some info for later, with zoomed-in y-axes
                 for (fld, a) in zip(fields, a_all.ravel()):
                     lo = scipy.stats.mstats.mquantiles(

--- a/FCDR_HIRS/analysis/summarise_fcdr.py
+++ b/FCDR_HIRS/analysis/summarise_fcdr.py
@@ -368,7 +368,7 @@ class FCDRSummary(HomemadeDataset):
                             a.set_title(total_title)
                     if fld in labels.keys():
                         a.set_ylabel(labels[fld])
-                    if i>0 and (len(ptiles)>1 or len(sats)>1):
+                    if i==0 and (len(ptiles)>1 or len(sats)>1):
                         a.legend(loc="upper left", bbox_to_anchor=(1, 1))
                     a.grid(axis="both")
                 # prepare some info for later, with zoomed-in y-axes

--- a/FCDR_HIRS/analysis/summarise_fcdr.py
+++ b/FCDR_HIRS/analysis/summarise_fcdr.py
@@ -33,6 +33,15 @@ def parse_cmdline():
         help="Version to use.")
 #            "or plot from them")
 
+    parser.add_argument("--ptiles", action="store", type=int,
+        nargs="*",
+        default=[5, 25, 50, 75, 95],
+        help="Percentiles to plot.  Recommended to plot at least always 50.")
+
+    parser.add_argument("--pstyles", action="store", type=str,
+        default=": -- - -- :",
+        help="Style for percentiles.  Should be single string argument "
+            "to prevent styles misinterpreted as flag hyphens.")
     p = parser.parse_args()
     return p
 parsed_cmdline = parse_cmdline()
@@ -98,7 +107,7 @@ class FCDRSummary(HomemadeDataset):
     time_field = "date"
     read_returns = "xarray"
     plot_file = ("hirs_summary/"
-        "FCDR_hirs_summary_{satname:s}_ch{channel:d}_{start:%Y%m%d}-{end:%Y%m%d}"
+        "FCDR_hirs_summary_{satname:s}_ch{channel:d}_{start:%Y%m%d}-{end:%Y%m%d}_p{ptilestr:s}"
         "v{data_version:s}.")
     plot_hist_file = ("hirs_summary/"
         "FCDR_hirs_hist_{satname:s}_{start:%Y%m%d}-{end:%Y%m%d}"
@@ -396,7 +405,8 @@ class FCDRSummary(HomemadeDataset):
             (f, a_all) = figs[channel]
             pyatmlab.graphics.print_or_show(f, None, 
                 self.plot_file.format(satname=satlabel, start=start,
-                end=end, channel=channel, data_version=self.data_version))
+                end=end, channel=channel, data_version=self.data_version,
+                ptilestr=','.join(str(p) for p in ptiles)))
         # another set with zoomed-in y-axes
         for channel in range(1, 20):
             (f, a_all) = figs[channel]
@@ -481,4 +491,6 @@ def summarise():
 #            fcdr_type="easy")
         summary.plot_period_ptiles(start, end,
             fields=["bt", "u_independent", "u_structured"],
-            fcdr_type="easy")
+            fcdr_type="easy",
+            ptiles=p.ptiles,
+            pstyles=p.pstyles.split())

--- a/FCDR_HIRS/analysis/summarise_fcdr.py
+++ b/FCDR_HIRS/analysis/summarise_fcdr.py
@@ -308,8 +308,9 @@ class FCDRSummary(HomemadeDataset):
         if sats is None:
             sats = self.satname
 
+        allsats = fcdr.list_all_satellites_chronologically()
         if sats == "all":
-            sats = fcdr.list_all_satellites_chronologically()
+            sats = allsats
             satlabel = ""
         else:
             sats = [sats]
@@ -345,10 +346,12 @@ class FCDRSummary(HomemadeDataset):
             else:
                 si = next(sc)
             
+            np = len(ptiles)
             if len(sats) == 1:
-                pcolors = ["C2", "C1", "C0", "C1", "C2"]
+                pcolors = [f"C{i:d}" for i in
+                    range(math.ceil(-np/2), math.ceil(np/2))]
             else:
-                pcolors = [f"C{si%10:d}"]*5
+                pcolors = [f"C{allsats.index(sat)%10:d}"]*np
 
             for channel in range(1, 20):
                 total_title = (f"HIRS {satlabel:s}ch. {channel:d} "

--- a/FCDR_HIRS/analysis/summarise_fcdr.py
+++ b/FCDR_HIRS/analysis/summarise_fcdr.py
@@ -300,8 +300,7 @@ class FCDRSummary(HomemadeDataset):
             sats = self.satname
 
         if sats == "all":
-            sats = sorted({norm_tovs_name(s) for s in
-                    fcdr.list_all_satellites()})
+            sats = fcdr.list_all_satellites_chronologically()
             satlabel = ""
         else:
             sats = [sats]

--- a/FCDR_HIRS/analysis/summarise_fcdr.py
+++ b/FCDR_HIRS/analysis/summarise_fcdr.py
@@ -347,7 +347,7 @@ class FCDRSummary(HomemadeDataset):
                 for (i, (fld, a)) in enumerate(zip(fields, a_all.ravel())):
                     #summary[fld].values[summary[fld]==0] = numpy.nan # workaround #126, redundant after fix
                     for (ptile, ls, color) in zip(sorted(ptiles), pstyles, pcolors):
-                        if i==0:
+                        if i!=0:
                             label = ""
                         elif len(sats)==1:
                             label = f"p-{ptile:d}"

--- a/FCDR_HIRS/analysis/summarise_fcdr.py
+++ b/FCDR_HIRS/analysis/summarise_fcdr.py
@@ -343,6 +343,12 @@ class FCDRSummary(HomemadeDataset):
         
         tit = f"HIRS {self.satname:s} {start:%Y-%m-%d}--{end:%Y-%m-%d}"
 
+        if fcdr_type == "easy":
+            lab_struc = "structured"
+            lab_indy = "independent"
+        else:
+            lab_struc = "T_b_nonrandom"
+            lab_indy = "T_b_random"
         # The dynamic range of structured uncertainties varies a lot
         # between channels.  Plotting together channels with large
         # differences in dynamic range of structured uncertainty may lead
@@ -350,8 +356,8 @@ class FCDRSummary(HomemadeDataset):
         # according to how much of the x-axis they need in their
         # histograms.
         idx_p95 = (summary.dims["bin_index"] -
-                  ((summary["hist_u_structured"].sum("date").cumsum("bin_index") /
-                    summary["hist_u_structured"].sum("date").sum("bin_index")) >
+                  ((summary[f"hist_u_{lab_struc:s}"].sum("date").cumsum("bin_index") /
+                    summary[f"hist_u_{lab_struc:s}"].sum("date").sum("bin_index")) >
                         .95).sum("bin_index"))
         ch_order = idx_p95.channel[idx_p95.values.argsort()]
         
@@ -362,16 +368,16 @@ class FCDRSummary(HomemadeDataset):
                 # take off last value because bins are the edges so
                 # this array is one longer than the corresponding hist
                 # values
-                x = summary["bins_u_independent"].sel(channel=ch)[:-1]
-                y = summary["hist_u_independent"].sel(channel=ch).sum("date")
-                a.plot(x, y, label=f"Ch. {ch:d}, independent",
+                x = summary[f"bins_u_{lab_indy:s}"].sel(channel=ch)[:-1]
+                y = summary[f"hist_u_{lab_indy:s}"].sel(channel=ch).sum("date")
+                a.plot(x, y, label=f"Ch. {ch:d}, {lab_indy:s}",
                     color=f"C{k:d}", linestyle="--")
-                y = summary["hist_u_structured"].sel(channel=ch).sum("date")
-                a.plot(x, y, label=f"Ch. {ch:d}, structured",
+                y = summary[f"hist_u_{lab_struc:s}"].sel(channel=ch).sum("date")
+                a.plot(x, y, label=f"Ch. {ch:d}, {lab_struc:s}",
                     color=f"C{k:d}", linestyle="-")
             a.legend()
             a.set_xlim([0,
-                float(summary["bins_u_structured"].sel(channel=chs[0]).isel(bin_edges=idx_hi))])
+                float(summary[f"bins_u_{lab_struc:s}"].sel(channel=chs[0]).isel(bin_edges=idx_hi))])
             a.set_xlabel("Brightness temperature uncertainty [K]")
             a.set_ylabel("Total number of pixels")
         f.suptitle(tit)

--- a/FCDR_HIRS/common.py
+++ b/FCDR_HIRS/common.py
@@ -20,7 +20,7 @@ def add_to_argparse(parser,
         parser.add_argument("satname", action="store", type=str.lower,
             help="Satellite name",
             metavar="satname",
-            choices=sorted(list_all_satellites()))
+            choices=sorted(list_all_satellites())+["all"])
     elif include_sat == 2:
         parser.add_argument("satname1", action="store", type=str,
             help="Satellite name, primary",

--- a/FCDR_HIRS/fcdr.py
+++ b/FCDR_HIRS/fcdr.py
@@ -2576,12 +2576,18 @@ def which_hirs_fcdr(satname, *args, **kwargs):
 
 def list_all_satellites():
     """Return a set with all possible satellite names of any kind
+
+    Includes duplicates!
     """
     S = set()
     for h in {HIRS2FCDR, HIRS3FCDR, HIRS4FCDR}:
         for sats in h.satellites.values():
             S |= sats
     return {x.lower() for x in S}
+
+def list_all_satellites_chronologically():
+    return ["tirosn"] + [f"noaa{i:d}" for i in range(6, 20) if i!=13] + [
+        "metopa", "metopb"]
 
 def _recursively_search_for(sub, var):
     """Search if 'var' already exists in the tree for

--- a/FCDR_HIRS/fcdr.py
+++ b/FCDR_HIRS/fcdr.py
@@ -2586,7 +2586,7 @@ def list_all_satellites():
     return {x.lower() for x in S}
 
 def list_all_satellites_chronologically():
-    return ["tirosn"] + [f"noaa{i:d}" for i in range(6, 20) if i!=13] + [
+    return ["tirosn"] + [f"noaa{i:02d}" for i in range(6, 20) if i!=13] + [
         "metopa", "metopb"]
 
 def _recursively_search_for(sub, var):


### PR DESCRIPTION
Fix and enhance monitoring script that plots long-term trends in the FCDR:

* Works again for `v0.8pre`;
* Skip flagged data;
* Allows to plot all satellites in a single plot;
* Use lower BT resolution in summary to reduce memory consumption;
* Same colours for same satellite regardless of what subset plotted;
* Option to pass on desired percentiles;
* Don't needlessly repeat legend;
* Restore grid;
* And some other things I'm forgetting right now.

And in the monitoring script that plots components of a single satellite uncertainty for a short time, make the flags plot higher so they are potentially readable.