### PR TITLE
Propagate beyond summation

### DIFF
--- a/FCDR_HIRS/_fcdr_defs.py
+++ b/FCDR_HIRS/_fcdr_defs.py
@@ -193,6 +193,38 @@ FCDR_data_vars_props = dict(
         {"long_name": "Number of PRTs for IWCT temperature measurement",
          "units": "1"},
         _u1_coding),
+    prt_reading = (
+        "prt_reading",
+        (),
+        {"long_name": "Number of PRT views per PRT for IWCT temperature measurement",
+         "units": "1"},
+        _u1_coding),
+    prt_iwct_polynomial_order = (
+        "prt_iwct_polynomial_order",
+        (),
+        {"long_name": "Order of polynomial for each IWCT PRT calibration",
+         "units": "1"},
+        _u1_coding),
+    prt_iwct_counts = (
+        "prt_iwct_counts",
+        ("time", "prt_number", "prt_reading"),
+        {"long_name": "IWCT PRT counts",
+         "units": ureg.count},
+        _count_coding),
+    prt_iwct_coefficients = (
+        "prt_iwct_coefficients",
+        ("prt_number", "prt_iwct_polynomial_order"),
+        {"long_name": "IWCT PRT coefficients",
+         "units": [ureg.K, ureg.K/ureg.count, ureg.K/ureg.count**2,
+                   ureg.K/ureg.count**3, ureg.K/ureg.count**4,
+                   ureg.K/ureg.count**4]},
+        _coding),
+    prt_iwct_temperature = (
+        "prt_iwct_temperature",
+        ("time", "prt_number", "prt_reading"),
+        {"long_name": "IWCT PRT temperature",
+         "units": ureg.K},
+        _temp_coding),
     B = (
         "planck_radiance_IWCT",
         ("calibration_cycle", "calibrated_channel"),
@@ -324,7 +356,8 @@ FCDR_data_vars_props = dict(
 p = FCDR_data_vars_props
 for (var, corr) in {("R_Earth", "O_Re"),
                     ("T_IWCT_calib_mean", "O_TIWCT"),
-                    ("R_IWCT", "O_RIWCT")}:
+                    ("R_IWCT", "O_RIWCT"),
+                    ("prt_iwct_temperature", "O_TPRT")}:
     FCDR_data_vars_props[corr] = (
         "corr_" + p[var][0],
         p[var][1],

--- a/FCDR_HIRS/effects.py
+++ b/FCDR_HIRS/effects.py
@@ -297,7 +297,7 @@ class Effect:
     measurement_equation module.
     """
 
-    _all_effects = {}
+    _all_effects = meq.ExpressionDict()
     name = None
     description = None
     parameter = None
@@ -320,7 +320,7 @@ class Effect:
         while len(later_pairs) > 0:
             (k, v) = later_pairs.pop()
             setattr(self, k, v)
-        if not self.parameter in self._all_effects.keys():
+        if not self.parameter in self._all_effects:
             self._all_effects[self.parameter] = set()
         self._all_effects[self.parameter].add(self)
 
@@ -394,7 +394,7 @@ class Effect:
         da.attrs["sensitivity_coefficient"] = str(self.sensitivity())
         da.attrs["WARNING"] = WARNING
 
-        if not self.name.startswith("O_") or self.name in _fcdr_defs.FCDR_data_vars_props.keys():
+        if not self.name.startswith("O_") or self.name in _fcdr_defs.FCDR_data_vars_props:
             da.encoding.update(_fcdr_defs.FCDR_data_vars_props[self.name][3])
         da.encoding.update(_fcdr_defs.FCDR_uncertainty_encodings.get(self.name, {}))
 
@@ -599,7 +599,7 @@ IWCT_PRT_counts_to_temp = Effect(
 IWCT_type_b = Effect(
     name="O_TPRT",
     description="IWCT type B",
-    parameter=meq.symbols["O_TPRT"],
+    parameter=sympy.IndexedBase(meq.symbols["O_TPRT"])[meq.symbols["n"],meq.symbols["m"]],
     correlation_type=_systematic,
     correlation_scale=_inf,
     unit=ureg.K,

--- a/FCDR_HIRS/effects.py
+++ b/FCDR_HIRS/effects.py
@@ -588,7 +588,7 @@ IWCT_PRT_counts_to_temp = Effect(
     parameter=meq.symbols["d_PRT"], # Relates to free_symbol but actual
         # parameter in measurement equation to be replaced relates to as
         # returned by typhon.physics.metrology.recursive_args; need to
-        # translate in some good way
+        # translate in some good way (see also #129)
     correlation_type=_systematic,
     correlation_scale=_inf,
     unit=ureg.counts/ureg.K, # FIXME WARNING: see https://github.com/FIDUCEO/FCDR_HIRS/issues/43

--- a/FCDR_HIRS/fcdr.py
+++ b/FCDR_HIRS/fcdr.py
@@ -1765,10 +1765,10 @@ class HIRSFCDR(typhon.datasets.dataset.HomemadeDataset):
             #all_effects = effects.effects()
 
 
-            if sbase in all_effects:
-                baddies = [eff for eff in all_effects[sbase]
+            if s in all_effects:
+                baddies = [eff for eff in all_effects[s]
                     if eff.magnitude is None]
-                goodies = [eff for eff in all_effects[sbase]
+                goodies = [eff for eff in all_effects[s]
                     if eff.magnitude is not None]
                 if baddies:
                     warnings.warn("Effects with unquantified "

--- a/FCDR_HIRS/measurement_equation.py
+++ b/FCDR_HIRS/measurement_equation.py
@@ -23,7 +23,63 @@ names = ("R_e a_0 a_1 a_2 C_s R_selfIWCT C_IWCT C_E R_selfE R_selfs ε λ Δλ "
 
 symbols = sym = dict(zip(names.split(), sympy.symbols(names)))
 
-expressions = {}
+class ExpressionDict(dict):
+    """Special version of dictionary where keys and values are sympy expressions
+
+    Special behaviour: When there is an IndexedBase key, this will match
+    even if the index is different.  For example, if the key is T_PRT[n]
+    and we request T_PRT[0], it will return D[T_PRT[n]] substituting n by
+    0.
+    """
+
+    def __getitem__(self, k):
+        if isinstance(k, sympy.tensor.indexed.Indexed):
+            try:
+                return super().__getitem__(k)
+            except KeyError:
+                # search through indexed keys
+                matches = {km for km in self.keys()
+                        if isinstance(km, sympy.tensor.indexed.Indexed)
+                    and k.args[0].args[0] == km.args[0].args[0]
+                    and len(k.args) == len(km.args)}
+                if len(matches) == 1:
+                    km = matches.pop()
+                    v = self[km]
+                    try:
+                        return v.subs(
+                            {str(k):v for (k,v) in zip(km.args[1:],
+                                k.args[1:])})
+                    except AttributeError: # not an expression
+                        return v
+                elif len(matches) == 0:
+                    raise
+                else:
+                    raise KeyError("Multiple keys fulfill "
+                        "fuzzy expression match")
+        else:
+            return super().__getitem__(k)
+
+    def __contains__(self, k):
+        try:
+            self[k]
+        except KeyError:
+            return False
+        else:
+            return True
+
+    def __repr__(self):
+        return "ExpressionDict({" + super().__repr__() + "})"
+
+    def get(self, k, *args):
+        if k in self:
+            return self[k]
+        else:
+            return super().get(k, *args)
+
+    def __setitem__(self, k, v):
+        super().__setitem__(k, v) # here only so I can set breakpoint
+
+expressions = ExpressionDict()
 expressions[sym["R_e"]] = (
     sym["a_0"] + sym["a_1"]*sym["C_E"] + sym["a_2"]*sym["C_E"]**2 -
     sym["R_selfE"] + sym["O_Re"] + sym["a_4"])
@@ -72,7 +128,7 @@ expressions[sympy.IndexedBase(sym["T_PRT"])[sym["n"]]] = (
 expressions[sympy.IndexedBase(sym["T_PRT"])[sym["n"],sym["m"]]] = (
     sympy.Sum(sympy.IndexedBase(sym["d_PRT"])[sym["n"],sym["a"]] *
         sympy.IndexedBase(sym["C_PRT"])[sym["n"],sym["m"]]**sym["a"], (sym["a"], 0, sym["A"]-1))
-    + sym["O_TPRT"])
+    + sympy.IndexedBase(sym["O_TPRT"])[sym["n"],sym["m"]])
 
 #expressions[sym["φn"]] = (sympy.Function("φn")(sym["λ"]+sym["Δλ"]))
 #expressions[sym["φn"]] = (sympy.Function("φn")(sym["ν"]+sym["Δν"]))
@@ -89,6 +145,7 @@ expressions[sym["h"]] = sympy.sympify(scipy.constants.Planck)
 expressions[sym["k_b"]] = sympy.sympify(scipy.constants.Boltzmann)
 expressions[sym["M"]] = sympy.Number(5)
 expressions[sym["N"]] = sympy.Number(5) # FIXME: actually depends on HIRS version...
+expressions[sym["A"]] = sympy.Number(6)
 
 units = {}
 units[sym["c"]] = ureg.c
@@ -110,7 +167,7 @@ def recursive_substitution(e, stop_at=None, return_intermediates=False,
     """
     o = None
     intermediates = set()
-    if isinstance(e, sympy.Symbol) and e in expressions.keys():
+    if isinstance(e, sympy.Symbol) and e in expressions:
         return recursive_substitution(expressions[e],
             stop_at=stop_at, return_intermediates=return_intermediates,
             expressions=expressions)
@@ -159,7 +216,7 @@ for s in symbols.values():
 
 functions = {}
 for (sn, s) in symbols.items():
-    if s in dependencies.keys():
+    if s in dependencies:
         if dependencies[s]:
             functions[s] = sympy.Function(sn)(*(aliases.get(sm, sm) for sm in dependencies[s]))
 
@@ -237,13 +294,13 @@ def calc_sensitivity_coefficient(s1, s2):
 
     Arguments:
 
-        s1: Symbol
-        s2: Symbol
+        s1: sympy.Expr
+        s2: sympy.Expr
     """
 
-    if not isinstance(s1, Symbol):
+    if not isinstance(s1, sympy.Expr):
         s1 = symbols[s1]
-    if not isinstance(s2, Symbol):
+    if not isinstance(s2, sympy.Expr):
         s2 = symbols[s2]
 
     if s1 == s2:

--- a/FCDR_HIRS/measurement_equation.py
+++ b/FCDR_HIRS/measurement_equation.py
@@ -17,7 +17,7 @@ from typhon.physics.units.tools import UnitsAwareDataArray as UADA
 version = "β"
 
 names = ("R_e a_0 a_1 a_2 C_s R_selfIWCT C_IWCT C_E R_selfE R_selfs ε λ Δλ "
-         "a_3 R_refl d_PRT C_PRT k n K N h c k_b T_PRT T_IWCT B φn "
+         "a_3 R_refl d_PRT C_PRT a n m A N M h c k_b T_PRT T_IWCT B φn "
          "R_IWCT O_Re O_TIWCT O_TPRT α β Tstar λstar O_RIWCT f Δf fstar "
          "ν Δν νstar T_bstar T_b a_4 S h_0 h_1 h_2 h_3")
 
@@ -68,9 +68,12 @@ if version == "β":
 expressions[sym["T_IWCT"]] = (
     sympy.Sum(sympy.IndexedBase(sym["T_PRT"])[sym["n"]], (sym["n"], 0, sym["N"]))/sym["N"] + sym["O_TIWCT"])
 expressions[sympy.IndexedBase(sym["T_PRT"])[sym["n"]]] = (
-    sympy.Sum(sympy.IndexedBase(sym["d_PRT"])[sym["n"],sym["k"]] *
-        sympy.IndexedBase(sym["C_PRT"])[sym["n"]]**sym["k"], (sym["k"], 0, sym["K"]-1))
+    sympy.Sum(sympy.IndexedBase(sym["T_PRT"])[sym["n"],sym["m"]], (sym["m"], 0, sym["M"]))/sym["M"])
+expressions[sympy.IndexedBase(sym["T_PRT"])[sym["n"],sym["m"]]] = (
+    sympy.Sum(sympy.IndexedBase(sym["d_PRT"])[sym["n"],sym["a"]] *
+        sympy.IndexedBase(sym["C_PRT"])[sym["n"],sym["m"]]**sym["a"], (sym["a"], 0, sym["A"]-1))
     + sym["O_TPRT"])
+
 #expressions[sym["φn"]] = (sympy.Function("φn")(sym["λ"]+sym["Δλ"]))
 #expressions[sym["φn"]] = (sympy.Function("φn")(sym["ν"]+sym["Δν"]))
 expressions[sym["φn"]] = (sympy.Function("φn")(sym["f"]+sym["Δf"]))
@@ -84,16 +87,19 @@ expressions[sym["T_b"]] = (sym["T_bstar"] - sym["α"])/sym["β"]
 expressions[sym["c"]] = sympy.sympify(scipy.constants.speed_of_light)
 expressions[sym["h"]] = sympy.sympify(scipy.constants.Planck)
 expressions[sym["k_b"]] = sympy.sympify(scipy.constants.Boltzmann)
+expressions[sym["M"]] = sympy.Number(5)
+expressions[sym["N"]] = sympy.Number(5) # FIXME: actually depends on HIRS version...
 
 units = {}
 units[sym["c"]] = ureg.c
 units[sym["h"]] = ureg.h
 units[sym["k_b"]] = ureg.k
+units[sym["N"]] = units[sym["M"]] = ureg.dimensionless
 
 aliases = {}
-aliases[sym["T_PRT"]] = sympy.IndexedBase(sym["T_PRT"])[sym["n"]]
-aliases[sym["C_PRT"]] = sympy.IndexedBase(sym["C_PRT"])[sym["n"]]
-aliases[sym["d_PRT"]] = sympy.IndexedBase(sym["d_PRT"])[sym["n"],sym["k"]]
+#aliases[sym["T_PRT"]] = sympy.IndexedBase(sym["T_PRT"])[sym["n"]]
+#aliases[sym["C_PRT"]] = sympy.IndexedBase(sym["C_PRT"])[sym["n"]]
+#aliases[sym["d_PRT"]] = sympy.IndexedBase(sym["d_PRT"])[sym["n"],sym["k"]]
 
 def recursive_substitution(e, stop_at=None, return_intermediates=False,
         expressions=expressions):
@@ -180,6 +186,8 @@ names = {
     sym["a_2"]: "a_2",
     sym["T_IWCT"]: "T_IWCT_calib_mean",
     sym["N"]: "prt_number_iwt",
+    sym["M"]: "prt_reading",
+    sym["A"]: "prt_iwct_polynomial_order",
     sym["Tstar"]: "Tstar",
     sym["B"]: "B",
     sym["O_Re"]: "O_Re",
@@ -190,6 +198,10 @@ names = {
     sym["k_b"]: "boltzmann_constant",
     sym["T_b"]: "T_b",
     sym["T_bstar"]: "T_bstar",
+    sym["C_PRT"]: "prt_iwct_counts",
+    sym["d_PRT"]: "prt_iwct_coefficients",
+    sym["T_PRT"]: "prt_iwct_temperature",
+    sym["O_TPRT"]: "O_TPRT",
 }
 
 

--- a/FCDR_HIRS/metrology.py
+++ b/FCDR_HIRS/metrology.py
@@ -933,7 +933,7 @@ def accum_sens_coef(sensdict: Dict[sympy.Symbol, Tuple[numpy.ndarray, Dict[sympy
     if _d is None:
         _d = collections.deque([1])
 
-    if sym in sensdict.keys():
+    if sym in sensdict:
         _d.append(sensdict[sym][0])
         return _d
 

--- a/FCDR_HIRS/models.py
+++ b/FCDR_HIRS/models.py
@@ -282,7 +282,7 @@ class RSelf:
             raise ValueError("Space views fail normality test: "
                 f"test statistic {tr.statistic:.3f}, p-value "
                 f"{tr.pvalue:9.3e}. Is the gain changing?")
-        if ch not in self.models.keys():
+        if ch not in self.models:
             self.models[ch] = copy.copy(self.core_model)
         self.models[ch].fit(Xx, Yy)
         self.X_ref = X

--- a/FCDR_HIRS/processing/generate_fcdr.py
+++ b/FCDR_HIRS/processing/generate_fcdr.py
@@ -350,7 +350,7 @@ class FCDRGenerator:
         # xarray bug is not triggered
         R_E = self.fcdr.calculate_radiance_all(subset,
             context=context, Rself_model=self.rself)
-        cu = {}
+        cu = {} # should NOT be an expressiondict, I don't want T[1]==T[2] here!
         (uRe, sensRe, compRe) = self.fcdr.calc_u_for_variable(
             "R_e", self.fcdr._quantities, self.fcdr._effects, cu,
             return_more=True)


### PR DESCRIPTION
Make it possible to propagate beyond the summation, essentially by expanding the summation.  Some work was needed to make the necessary bits of code aware of `IndexedBase` quantities, most notably a special dictionary that, where appropriate, understands that `T_PRT[1, 2]` can be derived when a sympy expression with `T_PRT[n, m]` is stored (the `ExpressionDict`).  Fixes #129.  Closes #129.