### PR TITLE
Workaround xarray catch warnings

### DIFF
--- a/FCDR_HIRS/fcdr.py
+++ b/FCDR_HIRS/fcdr.py
@@ -2746,3 +2746,14 @@ def _new_array_notnull_equiv(arr1, arr2):
         return bool(flag_array.all())
 
 xarray.core.duck_array_ops.array_notnull_equiv = _new_array_notnull_equiv
+
+def _new_array_eq(self, other):
+    with _do_nothing():
+        return xarray.core.nputils._ensure_bool_is_ndarray(self == other, self, other) 
+
+def _new_array_ne(self, other):
+    with _do_nothing():
+        return xarray.core.nputils._ensure_bool_is_ndarray(self != other, self, other) 
+
+xarray.core.nputils.array_eq = _new_array_eq
+xarray.core.nputils.array_ne = _new_array_ne


### PR DESCRIPTION
There are now yet more places in which xarray uses numpy.catch_warnings.  That makes me unhappy, for it triggers the bug at https://bugs.python.org/issue29672 which causes warnings to flood.  Do yet more monkey-patching and other dirty stuff to shut it all up.