### PR TITLE
Format fixes

### DIFF
--- a/FCDR_HIRS/_fcdr_defs.py
+++ b/FCDR_HIRS/_fcdr_defs.py
@@ -469,6 +469,30 @@ FCDR_extra_attrs = dict(
                   "treatment, please use full FCDR.")}
     )
 
+
+# TB writer 2018-08-21 (1.1.5):
+#
+# In : easy["quality_pixel_bitmask"].flag_meanings
+# 'invalid use_with_caution invalid_input invalid_geoloc invalid_time
+# sensor_error padded_data incomplete_channel_data'
+#
+# In : easy["data_quality_bitmask"].flag_meanings
+# 'suspect_mirror suspect_geo suspect_time outlier_nos
+# uncertainty_too_large'
+#
+# In : easy["quality_scanline_bitmask"].flag_meanings
+# 'do_not_use_scan time_sequence_error data_gap_preceding_scan
+# no_calibration no_earth_location clock_update status_changed
+# line_incomplete, time_field_bad time_field_bad_not_inf
+# inconsistent_sequence scan_time_repeat uncalib_bad_time calib_few_scans
+# uncalib_bad_prt calib_marginal_prt uncalib_channels uncalib_inst_mode
+# quest_ant_black_body zero_loc bad_loc_time bad_loc_marginal bad_loc_reason
+# bad_loc_ant reduced_context bad_temp_no_rself'
+#
+# In : easy["quality_channel_bitmask"].flag_meanings
+# 'do_not_use uncertainty_suspicious self_emission_fails
+# calibration_impossible calibration_suspect'
+
 @enum.unique
 class FlagsScanline(enum.IntFlag):
     DO_NOT_USE = enum.auto()

--- a/FCDR_HIRS/_fcdr_defs.py
+++ b/FCDR_HIRS/_fcdr_defs.py
@@ -360,6 +360,29 @@ FCDR_data_vars_props = dict(
         ("time",),
         {"long_name": "Original filename in L1B"},
         _str_coding),
+    platform_zenith_angle = (
+        "platform_zenith_angle",
+        ("scanline_earth", "scanpos"),
+        {"long_name": "Zenith angle of satellite as seen from the ground",
+         "units": "degrees"},
+        _ang_coding),
+    platform_azimuth_angle = (
+        "platform_azimuth_angle",
+        ("scanline_earth", "scanpos"),
+        {"long_name": "Azimuth angle (from the north) of satellite as seen from the ground",
+         "units": "degrees"},
+        _ang_coding),
+    solar_zenith_angle = (
+        "solar_zenith_angle",
+        ("scanline_earth", "scanpos"),
+        {"long_name": "Zenith angle of the Sun as seen from the ground",
+         "units": "degrees"},
+        _ang_coding),
+    solar_azimuth_angle = (
+        "solar_azimuth_angle",
+        ("scanline_earth", "scanpos"),
+        {"long_name": "Azimuth angle (from the north) of the Sun as seen from the ground"},
+        _ang_coding),
 )
 
 p = FCDR_data_vars_props

--- a/FCDR_HIRS/_fcdr_defs.py
+++ b/FCDR_HIRS/_fcdr_defs.py
@@ -28,6 +28,10 @@ _corr_coding["dtype"] = "u2"
 _corr_coding["scale_factor"] = 0.001
 _corr_coding["_FillValue"] = _u2_coding["_FillValue"]
 
+_str_coding = _coding.copy()
+del _str_coding["dtype"]
+del _str_coding["_FillValue"]
+
 # FIXME: uncertainty does NOT always have the same dimensions as quantity
 # it belongs to...
 
@@ -351,6 +355,11 @@ FCDR_data_vars_props = dict(
         {"long_name": "Channel error correlation matrix for structured effects",
          "units": "scanlines"},
         _corr_coding),
+    filename = (
+        "filename",
+        ("time",),
+        {"long_name": "Original filename in L1B"},
+        _str_coding),
 )
 
 p = FCDR_data_vars_props

--- a/FCDR_HIRS/fcdr.py
+++ b/FCDR_HIRS/fcdr.py
@@ -2370,7 +2370,7 @@ class HIRSFCDR(typhon.datasets.dataset.HomemadeDataset):
         # satellite angles
         satlatlon = ds[["lat","lon"]].sel(
             scanpos=[math.floor(self.n_perline/2),
-                     math.ceil(self.n_perline/2)])
+                     math.ceil(self.n_perline/2)]).reset_coords(["lat", "lon"])
         if numpy.sign(satlatlon["lon"]).prod()<0:
             # we're crossing the antimeridian
             satlatlon["lon"] += 360

--- a/FCDR_HIRS/fcdr.py
+++ b/FCDR_HIRS/fcdr.py
@@ -170,7 +170,7 @@ class HIRSFCDR(typhon.datasets.dataset.HomemadeDataset):
             cond = {"calibrate": (None, True)}
             self.my_pseudo_fields["radiance_fid_naive"] = (
                 ["radiance", self.scantype_fieldname, "temp_iwt", "time"],
-                lambda M, D:
+                lambda M, D, H, fn:
                 self.calculate_radiance_all(
                     M[1] if isinstance(M, tuple) else M, 
                     return_ndarray=True,
@@ -1547,7 +1547,7 @@ class HIRSFCDR(typhon.datasets.dataset.HomemadeDataset):
 #        return ureg.Quantity(numpy.ma.concatenate([rad.m[...,
 #            numpy.newaxis] for rad in all_rad], 2), all_rad[0].u)
 
-    def calculate_bt_all(self, M, D): 
+    def calculate_bt_all(self, M, D, H=None, fn=None): 
         if isinstance(D["radiance_fid_naive"], xarray.DataArray):
             bt_all = xarray.concat(
                 [D["radiance_fid_naive"].sel(channel=i).to(

--- a/FCDR_HIRS/fcdr.py
+++ b/FCDR_HIRS/fcdr.py
@@ -16,7 +16,8 @@ import progressbar
 import pandas
 import xarray
 import sympy
-import pyorbital
+import pyorbital.orbital
+import pyorbital.astronomy
 
 from typhon.physics.units.tools import UnitsAwareDataArray as UADA
 from typhon.utils import get_time_dimensions
@@ -596,6 +597,8 @@ class HIRSFCDR(typhon.datasets.dataset.HomemadeDataset):
                 dims=dims if dims is not None else [d for d in self._data_vars_props[name][1] if d not in dropdims],
                 attrs=self._data_vars_props[name][2],
                 encoding=self._data_vars_props[name][3])
+        if not da.name:
+            da.name = self._data_vars_props[name][0]
         # also drop dimensions when they are now dimensionless coordinates
         for d in dropdims:
             if d in da.coords:
@@ -2368,30 +2371,56 @@ class HIRSFCDR(typhon.datasets.dataset.HomemadeDataset):
         satlatlon = ds[["lat","lon"]].sel(
             scanpos=[math.floor(self.n_perline/2),
                      math.ceil(self.n_perline/2)])
+        if numpy.sign(satlatlon["lon"]).prod()<0:
+            # we're crossing the antimeridian
+            satlatlon["lon"] += 360
+            satlatlon = satlatlon.mean("scanpos")
+            if satlatlon["lon"].item() > 360:
+                satlatlon["lon"] -= 360
+        else:
+            # not very accurate, but this is a temporary solution anyway,
+            # as ultimately the satellite lat/lon needs to be recalculated
+            # from TLEs when we redo the geolocation (#235)
+            satlatlon = satlatlon.mean("scanpos")
         satelev = ds["platform_altitude"]
-        (sat_aa, sat_za) = pyorbital.orbital.get_observer_look(
+        (sat_aa, sat_ea) = pyorbital.orbital.get_observer_look(
             satlatlon["lon"],
             satlatlon["lat"],
             satelev,
             ds["time"], # FIXME: Who cares?
             ds["lon"],
             ds["lat"],
-            numpy.zeros(ds.dims["scanline_earth"]))
+            numpy.zeros(ds["lat"].shape)) # elevations
             
         (sun_el_rad, sun_az_rad) = pyorbital.astronomy.get_alt_az(
             ds["time"],
             ds["lon"],
             ds["lat"])
 
-        sun_za = 90 - numpy.rad2deg(sun_el_rad)
-        sun_aa = numpy.rad2deg(sun_az_rad)
+        sun_za = self._quantity_to_xarray(
+            90 - numpy.rad2deg(sun_el_rad),
+            "solar_zenith_angle")
+        sun_aa = self._quantity_to_xarray(
+            numpy.rad2deg(sun_az_rad),
+            "solar_azimuth_angle")
+        sat_za = self._quantity_to_xarray(
+            90 - sat_ea,
+            "platform_zenith_angle")
+        sat_aa = self._quantity_to_xarray(
+            sat_aa,
+            "platform_azimuth_angle")
 
         return (sat_za, sat_aa, sun_za, sun_aa)
 
 
-    # deprecated:
+    #####################################################################
+    #
+    #   DEPRECATED!
+    #
     # The remaining methods should no longer be used but legacy code such
     # as in timeseries.py still depends on them
+    #
+    #####################################################################
 
     def calc_sens_coef(self, typ, M, ch, srf): 
         """Calculate sensitivity coefficient.

--- a/FCDR_HIRS/matchups.py
+++ b/FCDR_HIRS/matchups.py
@@ -212,9 +212,9 @@ class HIRSMatchupCombiner:
                     for s in (prim_name, sec_name)}|{"matchup_spherical_distance"},
                 pseudo_fields={
                     "time_{:s}".format(prim_name):
-                        lambda ds: ds["hirs-{:s}_time".format(prim_name)][:, 3, 3].astype("M8[s]"),
+                        lambda ds, D=None, H=None, fn=None: ds["hirs-{:s}_time".format(prim_name)][:, 3, 3].astype("M8[s]"),
                     "time_{:s}".format(sec_name):
-                        lambda ds: ds["hirs-{:s}_time".format(sec_name)][:, 3, 3].astype("M8[s]")},
+                        lambda ds, D=None, H=None, fn=None: ds["hirs-{:s}_time".format(sec_name)][:, 3, 3].astype("M8[s]")},
                 orbit_filters=hh.default_orbit_filters+[HHMatchupCountFilter(prim_name,sec_name)])
             self.prim_hirs = fcdr.which_hirs_fcdr(prim_name, read="L1C")
 

--- a/FCDR_HIRS/processing/generate_fcdr.py
+++ b/FCDR_HIRS/processing/generate_fcdr.py
@@ -809,61 +809,69 @@ class FCDRGenerator:
         eqcb = easy["quality_channel_bitmask"]
 
 
-        # placeholders, to be filled in
-
+        # placeholders with noidx to be filled in
         noidx = numpy.zeros(0, dtype="u2")
 
-        # efqpb
+        # efqpb (this is shared between sensors)
         eqpb[dpb&dfp.DO_NOT_USE] |= efqpb.invalid
-        eqpb[noidx] |= efqpb.incomplete_channel_data
-        eqpb[noidx] |= efqpb.invalid_geoloc
-        eqpb[noidx] |= efqpb.invalid_input
-        eqpb[noidx] |= efqpb.invalid_time
-        eqpb[noidx] |= efqpb.padded_data
-        eqpb[noidx] |= efqpb.sensor_error
-        eqpb[noidx] |= efqpb.use_with_caution
+        eqpb[noidx] |= efqpb.incomplete_channel_data # FIXME
+        eqpb[noidx] |= efqpb.invalid_geoloc # FIXME: expand from dsb&dfs.SUSPECT_GEO 
+        eqpb[noidx] |= efqpb.invalid_input # FIXME: ?
+        eqpb[noidx] |= efqpb.invalid_time # FIXME: expand from dsb&dfs.SUSPECT_TIME
+        eqpb[noidx] |= efqpb.padded_data # FIXME: ?
+        eqpb[noidx] |= efqpb.sensor_error # FIXME: ?
+        eqpb[noidx] |= efqpb.use_with_caution # FIXME: ?
 
         # efdqb
-        edqb[noidx] |= efdqb.outlier_nos
-        edqb[noidx] |= efdqb.suspect_geo
-        edqb[noidx] |= efdqb.suspect_mirror
-        edqb[noidx] |= efdqb.suspect_time
-        edqb[noidx] |= efdqb.uncertainty_too_large
+        edqb[dpb&dfp.OUTLIER_NOS] |= efdqb.outlier_nos
+        edqb[noidx] |= efdqb.suspect_geo # FIXME: from dfs or should be in eqsb; same as invalid_geoloc?
+        edqb[noidx] |= efdqb.suspect_mirror # FIXME: from dfmf&dmfb.SUSPECT_MIRROR
+        edqb[noidx] |= efdqb.suspect_time # FIXME: should be in eqsb; same as invalid_time?
+        edqb[dpb&dfp.UNCERTAINTY_TOO_LARGE] |= efdqb.uncertainty_too_large
 
         # efqsb
-        eqsb[noidx] |= efqsb.do_not_use_scan
-        eqsb[noidx] |= efqsb.bad_loc_ant
-        eqsb[noidx] |= efqsb.bad_loc_marginal
-        eqsb[noidx] |= efqsb.bad_loc_reason
-        eqsb[noidx] |= efqsb.bad_loc_time
-        eqsb[noidx] |= efqsb.bad_temp_no_rself
-        eqsb[noidx] |= efqsb.calib_few_scans
-        eqsb[noidx] |= efqsb.calib_marginal_prt
-        eqsb[noidx] |= efqsb.clock_update
-        eqsb[noidx] |= efqsb.data_gap_preceding_scan
-        eqsb[noidx] |= efqsb.inconsistent_sequence
-        eqsb[noidx] |= efqsb.line_incomplete
-        eqsb[noidx] |= efqsb.no_calibration
-        eqsb[noidx] |= efqsb.no_earth_location
-        eqsb[noidx] |= efqsb.quest_ant_black_body
-        eqsb[noidx] |= efqsb.reduced_context
-        eqsb[noidx] |= efqsb.scan_time_repeat
-        eqsb[noidx] |= efqsb.status_changed
-        eqsb[noidx] |= efqsb.time_field_bad
-        eqsb[noidx] |= efqsb.time_field_bad_not_inf
-        eqsb[noidx] |= efqsb.time_sequence_error
-        eqsb[noidx] |= efqsb.uncalib_bad_prt
-        eqsb[noidx] |= efqsb.uncalib_bad_time
-        eqsb[noidx] |= efqsb.uncalib_channels
-        eqsb[noidx] |= efqsb.uncalib_inst_mode
-        eqsb[noidx] |= efqsb.zero_loc
+        # FIXME: this contains too much information for easy
+        eqsb[dsb&dfs.DO_NOT_USE] |= efqsb.do_not_use_scan
+        eqsb[noidx] |= efqsb.bad_loc_ant # FIXME: ?
+        eqsb[noidx] |= efqsb.bad_loc_marginal # FIXME: ?
+        eqsb[noidx] |= efqsb.bad_loc_reason # FIXME: ?
+        eqsb[noidx] |= efqsb.bad_loc_time # FIXME: ?
+        eqsb[dsb&dfs.BAD_TEMP_NO_RSELF] |= efqsb.bad_temp_no_rself
+        eqsb[noidx] |= efqsb.calib_few_scans # FIXME: ?
+        eqsb[noidx] |= efqsb.calib_marginal_prt # FIXME: ?
+        eqsb[noidx] |= efqsb.clock_update # FIXME: ?
+        eqsb[noidx] |= efqsb.data_gap_preceding_scan # FIXME: ?
+        eqsb[noidx] |= efqsb.inconsistent_sequence # FIXME: ?
+        eqsb[noidx] |= efqsb.line_incomplete # FIXME: ?
+        eqsb[noidx] |= efqsb.no_calibration # FIXME dfs.SUSPECT_CALIB?
+        eqsb[noidx] |= efqsb.no_earth_location # FIXME: ?
+        eqsb[noidx] |= efqsb.quest_ant_black_body # FIXME: ?
+        eqsb[dsb&dfs.REDUCED_CONTEXT] |= efqsb.reduced_context
+        eqsb[noidx] |= efqsb.scan_time_repeat # FIXME: ?
+        eqsb[noidx] |= efqsb.status_changed # FIXME: ?
+        eqsb[noidx] |= efqsb.time_field_bad # FIXME: ?
+        eqsb[noidx] |= efqsb.time_field_bad_not_inf # FIXME: ?
+        eqsb[noidx] |= efqsb.time_sequence_error # FIXME: ?
+        eqsb[noidx] |= efqsb.uncalib_bad_prt # FIXME: ?
+        eqsb[noidx] |= efqsb.uncalib_bad_time # FIXME: ?
+        eqsb[noidx] |= efqsb.uncalib_channels # FIXME: ?
+        eqsb[noidx] |= efqsb.uncalib_inst_mode # FIXME: ?
+        eqsb[noidx] |= efqsb.zero_loc # FIXME: ?
+        
+        # MISSING:
+        #
+        # SUSPECT_CALIB
+        # SUSPECT_GEO
+        # SUSPECT_MIRROR_ANY
+        # SUSPECT_TIME
+        # UNCERTAINTY_SUSPICIOUS
 
         # efqcb
-        eqcb[noidx] |= efqcb.do_not_use
-        eqcb[noidx] |= efqcb.calibration_impossible
-        eqcb[noidx] |= efqcb.calibration_suspect
-        eqcb[noidx] |= efqcb.self_emission_fails
-        eqcb[noidx] |= efqcb.uncertainty_suspicious
+        eqcb[dcb&dfc.DO_NOT_USE] |= efqcb.do_not_use
+        eqcb[dcb&dfc.CALIBRATION_IMPOSSIBLE] |= efqcb.calibration_impossible
+        eqcb[noidx] |= efqcb.calibration_suspect # FIXME: ?
+        eqcb[dcb&dfc.SELF_EMISSION_FAILS] |= efqcb.self_emission_fails
+        eqcb[dcb&dfc.UNCERTAINTY_SUSPICIOUS] |= efqcb.uncertainty_suspicious
 
 
         # summarise per line

--- a/FCDR_HIRS/processing/generate_fcdr.py
+++ b/FCDR_HIRS/processing/generate_fcdr.py
@@ -648,10 +648,10 @@ class FCDRGenerator:
             quality_channel_bitmask = piece["quality_channel_bitmask"],
             u_independent=piece["u_T_b_random"],
             u_structured=piece["u_T_b_nonrandom"],
-            u_common=piece["u_T_b_harm"], # NB: not in TBs writer yet!
+            u_common=piece["u_T_b_harm"], # NB 2018-08-02: not in TBs writer yet!
             lookup_table_BT=piece["lookup_table_BT"],
             lookup_table_radiance=piece["lookup_table_radiance"],
-            scanline_origl1b=piece["scanline_number"])
+            scanline_origl1b=piece["scanline_number"].sel(time=t_earth))
         try:
             newcont.update(**dict(
 #                cross_line_radiance_error_correlation_length_scale_structured_effects=piece["cross_line_radiance_error_correlation_length_scale_structured_effects"],
@@ -695,7 +695,7 @@ class FCDRGenerator:
         easy = easy.assign(**transfer)
         
         # add orig_l1b
-        src_filenames = pandas.unique(piece["filename"])
+        src_filenames = pandas.unique(piece["filename"].sel(time=t_earth))
         easy["scanline_map_to_origl1bfile"] = [src_filenames.tolist().index(fn) for fn in piece["filename"]]
         easy.attrs["source"] = src_filenames
 

--- a/FCDR_HIRS/processing/generate_fcdr.py
+++ b/FCDR_HIRS/processing/generate_fcdr.py
@@ -616,6 +616,8 @@ class FCDRGenerator:
         "scanpos": "x",
         "channel": "rad_channel",
         "calibrated_channel": "channel",
+        "delta_scanline_earth": "delta_y",
+        "delta_scanpos": "delta_x",
         }
 
     map_names_debug_to_easy = {

--- a/FCDR_HIRS/processing/generate_fcdr.py
+++ b/FCDR_HIRS/processing/generate_fcdr.py
@@ -664,7 +664,7 @@ class FCDRGenerator:
                 channel_correlation_matrix_independent=piece["cross_channel_error_correlation_matrix_independent_effects"],
                 channel_correlation_matrix_structured=piece["cross_channel_error_correlation_matrix_structured_effects"],
                 cross_element_correlation_coefficients=piece["cross_element_radiance_error_correlation_length_average"],
-                cross_line_correlation_coefficients=piece["cross_line_radiance_error_correlation_length_average"].isel(delta_scanline_earth=slice(easy.dims["delta_scanline_earth"])),
+                cross_line_correlation_coefficients=piece["cross_line_radiance_error_correlation_length_average"].isel(delta_scanline_earth=slice(easy.dims["delta_y"])),
                     ))
         except KeyError as e:
             # assuming they're missing because their calculation failed

--- a/FCDR_HIRS/processing/generate_fcdr.py
+++ b/FCDR_HIRS/processing/generate_fcdr.py
@@ -696,7 +696,7 @@ class FCDRGenerator:
         
         # add orig_l1b
         src_filenames = pandas.unique(piece["filename"].sel(time=t_earth))
-        easy["scanline_map_to_origl1bfile"][:] = [src_filenames.tolist().index(fn) for fn in piece["filename"]]
+        easy["scanline_map_to_origl1bfile"][:] = [src_filenames.tolist().index(fn) for fn in piece["filename"].sel(time=t_earth)]
         easy.attrs["source"] = src_filenames
 
         easy = easy.assign_coords(

--- a/FCDR_HIRS/processing/generate_fcdr.py
+++ b/FCDR_HIRS/processing/generate_fcdr.py
@@ -674,8 +674,15 @@ class FCDRGenerator:
                 "See above, I guess their calculation failed. "
                 f"For the record: {e.args[0]}")
 
-        if self.fcdr.version >= 3:
-            newcont.update(
+        (sat_za, sat_aa, sun_za, sun_aa) = self.fcdr.calc_angles(piece)
+        # FIXME: should go into debug as well?
+        newcont.update(
+            satellite_zenith_angle=sat_za,
+            satellite_azimuth_angle=sat_aa,
+            solar_zenith_angle=sun_za,
+            solar_azimuth_angle=sun_aa)
+#        if self.fcdr.version >= 3:
+#            newcont.update(
 #                linqualflags=piece["line_quality_flags"].sel(time=t_earth),
 #                chqualflags=piece["channel_quality_flags"].sel(
 #                    time=t_earth,
@@ -685,13 +692,13 @@ class FCDRGenerator:
 #                    time=t_earth,
 #                    minor_frame=slice(56)).rename(
 #                    {"minor_frame": "scanpos"}), # see #73 (TODO: #74, #97)
-                satellite_azimuth_angle=piece["local_azimuth_angle"].sel(time=t_earth),
-                solar_zenith_angle=piece["solar_zenith_angle"].sel(time=t_earth),
-                )
-        else:
-            easy = easy.drop(easy.data_vars.keys() &
-                {"solar_zenith_angle", "solar_azimuth_angle",
-                 "satellite_azimuth_angle"})
+#                satellite_azimuth_angle=piece["local_azimuth_angle"].sel(time=t_earth),
+#                solar_zenith_angle=piece["solar_zenith_angle"].sel(time=t_earth),
+#                )
+#        else:
+#            easy = easy.drop(easy.data_vars.keys() &
+#                {"solar_zenith_angle", "solar_azimuth_angle",
+#                 "satellite_azimuth_angle"})
             #newcont["local_azimuth_angle"] = None
             #newcont["solar_zenith_angle"] = None
         # if we are going to respect Toms template this should contain

--- a/FCDR_HIRS/processing/generate_fcdr.py
+++ b/FCDR_HIRS/processing/generate_fcdr.py
@@ -650,7 +650,8 @@ class FCDRGenerator:
             u_structured=piece["u_T_b_nonrandom"],
             u_common=piece["u_T_b_harm"], # NB: not in TBs writer yet!
             lookup_table_BT=piece["lookup_table_BT"],
-            lookup_table_radiance=piece["lookup_table_radiance"])
+            lookup_table_radiance=piece["lookup_table_radiance"],
+            scanline_origl1b=piece["scanline_number"])
         try:
             newcont.update(**dict(
 #                cross_line_radiance_error_correlation_length_scale_structured_effects=piece["cross_line_radiance_error_correlation_length_scale_structured_effects"],
@@ -692,6 +693,12 @@ class FCDRGenerator:
                     v)
                 for (k, v) in newcont.items()}
         easy = easy.assign(**transfer)
+        
+        # add orig_l1b
+        src_filenames = pandas.unique(piece["filename"])
+        easy["scanline_map_to_origl1bfile"] = [src_filenames.tolist().index(fn) for fn in piece["filename"]]
+        easy.attrs["source"] = src_filenames
+
         easy = easy.assign_coords(
             x=numpy.arange(1, 57),
             #y=easy["scanline"],

--- a/FCDR_HIRS/processing/generate_fcdr.py
+++ b/FCDR_HIRS/processing/generate_fcdr.py
@@ -696,7 +696,7 @@ class FCDRGenerator:
         
         # add orig_l1b
         src_filenames = pandas.unique(piece["filename"].sel(time=t_earth))
-        easy["scanline_map_to_origl1bfile"] = [src_filenames.tolist().index(fn) for fn in piece["filename"]]
+        easy["scanline_map_to_origl1bfile"][:] = [src_filenames.tolist().index(fn) for fn in piece["filename"]]
         easy.attrs["source"] = src_filenames
 
         easy = easy.assign_coords(

--- a/setup.py
+++ b/setup.py
@@ -105,6 +105,7 @@ setup(
                       "pint>=0.8",
                       "fcdr-tools>=1.1.4",
                       "joblib>=0.11",
+                      "pyorbital",
                       "cartopy"],
 
     # List additional groups of dependencies here (e.g. development


### PR DESCRIPTION
Implement various fixes related to the format:

* Now writes filename and original scanline number, closes #270.
* Fixes dimension on CURUC lengths, closes #258. 
* Sets bitmask according to TB format correctly, closes #269. 
* Added all angles for all satellites, with help of pyorbital, closes #104. 