### PR TITLE
Fix spurious harm coords

### DIFF
--- a/FCDR_HIRS/processing/combine_matchups.py
+++ b/FCDR_HIRS/processing/combine_matchups.py
@@ -581,10 +581,8 @@ class HIRSMatchupCombiner(matchups.HIRSMatchupCombiner):
         harm[f"nominal_measurand_uncertainty_structured{i:d}"].attrs.update(
             ds[f"{sat:s}_u_R_Earth_nonrandom"].attrs)
 
-        harm[f"lon{i:d}"] = ds[f"{sat:s}_longitude"].rename(
-                {"matchup_count": "M"})
-        harm[f"lat{i:d}"] = ds[f"{sat:s}_latitude"].rename(
-                {"matchup_count": "M"})
+        harm[f"lon{i:d}"] = ("M", ds[f"{sat:s}_longitude"])
+        harm[f"lat{i:d}"] = ("M", ds[f"{sat:s}_latitude"])
         
         harm[f"nominal_measurand_original{i:d}"] = (("M",),
             ds[f"{sat:s}_toa_outgoing_radiance_per_unit_frequency"].sel(channel=channel))

--- a/FCDR_HIRS/processing/combine_matchups.py
+++ b/FCDR_HIRS/processing/combine_matchups.py
@@ -862,7 +862,12 @@ def merge_all(*files):
     for k in ds_all[0].data_vars.keys()-ds_new.keys():
         if "M" in ds_all[0][k].dims:
             # Workaround for #285
-            spurious_coords = set(ds_all[-1].coords) - set(ds_all[0].coords)
+            spurious_coords = (functools.reduce(
+                    operator.or_,
+                    [set(da.coords) for da in ds_all]) 
+                        - functools.reduce(
+                    operator.and_,
+                    [set(da.coords) for da in ds_all]))
             try:
                 ds_new[k] = xarray.concat(
                     [da[k].drop({s for s in spurious_coords if s in da[k].coords})


### PR DESCRIPTION
In a rebase merge conflict I accidentally (re-)introduced a bug with spurious harmonisation coords.

This PR both fixes the bug and adds a workaround in the merging routine so it can repair the buggy inputs for a correct merged output file.

Fixes #285.