### PR TITLE
Adapt flag mapping to format change

### DIFF
--- a/FCDR_HIRS/analysis/map_single_orbit.py
+++ b/FCDR_HIRS/analysis/map_single_orbit.py
@@ -164,8 +164,9 @@ class OrbitPlotter:
 
     def plot_bitfield(self, ax, cax, t0, t1, da, tit):
         # https://gist.github.com/jakevdp/8a992f606899ac24b711
-        flagdefs = dict(zip(da.flag_masks,
-                            da.flag_meanings.split(",")))
+        flagdefs = dict(zip(
+            (int(x.strip()) for x in da.flag_masks.split(",")),
+            da.flag_meanings.split()))
 
 #        if not da.any():
 #            logging.warning("Current unable to plot "


### PR DESCRIPTION
The exact format in which flags are described in the netcdf data variable
attributes has changed since I first wrote this function.  Adapt the
plotting to reflect this.