### PR TITLE
Write debug as debug

### DIFF
--- a/FCDR_HIRS/processing/generate_fcdr.py
+++ b/FCDR_HIRS/processing/generate_fcdr.py
@@ -921,7 +921,8 @@ class FCDRGenerator:
                 self.satname,
                 from_time,
                 to_time,
-                self.data_version))
+                self.data_version).replace(
+                    "EASY", fcdr_type.upper()))
 #        raise NotImplementedError()
             
 


### PR DESCRIPTION
I introduced a bug in #307 where debug fcdr filenames had the label EASY.  Now they have DEBUG.