### PR TITLE
Improve orbit plotting

### DIFF
--- a/FCDR_HIRS/analysis/map_single_orbit.py
+++ b/FCDR_HIRS/analysis/map_single_orbit.py
@@ -23,7 +23,7 @@ def parse_cmdline():
         default=list(range(1, 13)))
 
     parser.add_argument("--range", action="store", type=int,
-        nargs=2, help="What fraction of orbit to plot, in %.  Normally 0-100.",
+        nargs=2, help="What fraction of orbit to plot, in %%.  Normally 0-100.",
         default=[0, 100])
 
     parser.add_argument("--verbose", action="store_true", default=False)

--- a/FCDR_HIRS/analysis/map_single_orbit.py
+++ b/FCDR_HIRS/analysis/map_single_orbit.py
@@ -22,7 +22,7 @@ def parse_cmdline():
         "for some fields.",
         default=list(range(1, 13)))
 
-    parser.add_argument("--range", action="store", type="int",
+    parser.add_argument("--range", action="store", type=int,
         nargs=2, help="What fraction of orbit to plot, in %.  Normally 0-100.",
         default=[0, 100])
 

--- a/FCDR_HIRS/math.py
+++ b/FCDR_HIRS/math.py
@@ -409,8 +409,9 @@ def gap_fill(ds, dim="time", coor="time", Δt=None):
     glnz = gaplength.nonzero()[0]
     glnzv = gaplength[glnz]
 
+    # add 1 to glnz because we want insertions before not after
     insertions = numpy.concatenate(
-        [numpy.repeat(c, v) for (v, c) in zip(glnzv, glnz)], 0)
+        [numpy.repeat(c, v) for (v, c) in zip(glnzv, glnz+1)], 0)
 
     # I need to drop any coordinates that shares a dimension with the
     # insertion dimension, or I run into
@@ -425,8 +426,8 @@ def gap_fill(ds, dim="time", coor="time", Δt=None):
                     v.drop([c for c in v.coords.keys() if dim in v[c].dims]),
                     insertions,
                     numpy.datetime64("NaT") if v.dtype.kind == "M" else
-                    v.encoding.get("_FillValue", 
-                        0 if isinstance(v.values.flat[0], numbers.Integral) else numpy.nan),
+                        numpy.nan if v.dtype.kind in "cf" else
+                        0,
                     axis=v.dims.index(dim))
                 if dim in v.dims else v
                   for (k, v) in ds.data_vars.items()}


### PR DESCRIPTION
Plot only a subset of an orbit, optionally leaving out the bitmasks.  If a subset, switch to a Plate Carree projection so that I can label the gridlines (see https://github.com/SciTools/cartopy/issues/881 for current limitations).  Add an option to label one or more pixels as desired.

Closes #311 
