### PR TITLE
in debug radiances, consider ε and non-linearity together consistently

### DIFF
--- a/FCDR_HIRS/fcdr.py
+++ b/FCDR_HIRS/fcdr.py
@@ -793,7 +793,7 @@ class HIRSFCDR(typhon.datasets.dataset.HomemadeDataset):
 
         # nonlinearity
         # order: see e-mail RQ 2018-04-06 and 2018-10-11
-        if self.no_harm or not self.include_nonlinearity:
+        if self.no_harm or not include_nonlinearity:
             a2 = UADA(0, 
                 name="a2", coords={"calibrated_channel": ch},
                 attrs = {"units": str(rad_u["si"]/(ureg.count**2))})

--- a/FCDR_HIRS/fcdr.py
+++ b/FCDR_HIRS/fcdr.py
@@ -793,7 +793,7 @@ class HIRSFCDR(typhon.datasets.dataset.HomemadeDataset):
 
         # nonlinearity
         # order: see e-mail RQ 2018-04-06 and 2018-10-11
-        if naive or self.no_harm:
+        if self.no_harm or not self.include_nonlinearity:
             a2 = UADA(0, 
                 name="a2", coords={"calibrated_channel": ch},
                 attrs = {"units": str(rad_u["si"]/(ureg.count**2))})

--- a/FCDR_HIRS/fcdr.py
+++ b/FCDR_HIRS/fcdr.py
@@ -1457,8 +1457,8 @@ class HIRSFCDR(typhon.datasets.dataset.HomemadeDataset):
                 (interp_offset_dbg, interp_slope_dbg,
                     interp_bad_dbg) = self.interpolate_between_calibs(
                         ds["time"], time,
-                        offset_noa3.median(dim="scanpos", keep_attrs=True),
-                        slope_noa3.median(dim="scanpos", keep_attrs=True),
+                        offset_dbg.median(dim="scanpos", keep_attrs=True),
+                        slope_dbg.median(dim="scanpos", keep_attrs=True),
                         bad, kind="zero")
 
                 rad_wn_dbg[lab] = self.custom_calibrate(


### PR DESCRIPTION
When calculating debug radiances, both slope and offset need to be consistently recalculated when either ε or nonlinearity corrections are left out, otherwise both will be wrong.  This will likely fix #337.