### PR TITLE
Do not pollute root logger

### DIFF
--- a/FCDR_HIRS/analysis/calibcounts_stats_per_scanpos.py
+++ b/FCDR_HIRS/analysis/calibcounts_stats_per_scanpos.py
@@ -274,7 +274,8 @@ def main():
     to_date = datetime.datetime.strptime(p.to_date, p.datefmt)
     common.set_logger(
         logging.DEBUG if p.verbose else logging.info,
-        p.log)
+        p.log,
+        loggers={"FCDR_HIRS", "typhon"})
     read_and_plot_calibcount_stats(p.satname, from_date, to_date,
         p.channels, p.plot_distributions, p.plot_examples,
         p.random_seed, 

--- a/FCDR_HIRS/analysis/convert_hirs_l1b_to_nc.py
+++ b/FCDR_HIRS/analysis/convert_hirs_l1b_to_nc.py
@@ -228,7 +228,8 @@ def convert_period(h, sat, start_date, end_date, **kwargs):
 
 def main():
     p = parse_cmdline()
-    common.set_logger(logging.INFO)
+    common.set_logger(logging.INFO,
+        loggers={"FCDR_HIRS", "typhon"})
     h = fcdr.which_hirs_fcdr(p.satname)
     convert_period(h, p.satname, 
             datetime.datetime.strptime(p.from_date, p.datefmt),

--- a/FCDR_HIRS/analysis/fieldmat.py
+++ b/FCDR_HIRS/analysis/fieldmat.py
@@ -1049,6 +1049,7 @@ def main():
     p = parse_cmdline()
     common.set_logger(
         logging.DEBUG if p.verbose else logging.INFO,
-        p.log)
+        p.log,
+        loggers={"FCDR_HIRS", "typhon"})
     matplotlib.pyplot.style.use(typhon.plots.styles("typhon"))
     read_and_plot_field_matrices(p)

--- a/FCDR_HIRS/analysis/hirs_iasi_srf_estimation.py
+++ b/FCDR_HIRS/analysis/hirs_iasi_srf_estimation.py
@@ -2702,7 +2702,8 @@ def main():
     p = parse_cmdline()
     common.set_logger(
         logging.DEBUG if p.verbose else logging.INFO,
-        p.log)
+        p.log,
+        loggers={"FCDR_HIRS", "typhon"})
         
     print(p)
     numexpr.set_num_threads(p.threads)

--- a/FCDR_HIRS/analysis/inspect_hirs_harm_matchups.py
+++ b/FCDR_HIRS/analysis/inspect_hirs_harm_matchups.py
@@ -469,6 +469,7 @@ def main():
 
     common.set_logger(
         logging.DEBUG if p.verbose else logging.INFO,
-        p.log)
+        p.log,
+        loggers={"FCDR_HIRS", "typhon"})
         
     plot_file_summary_stats(pathlib.Path(p.file), write=p.write_filters)

--- a/FCDR_HIRS/analysis/inspect_hirs_matchups.py
+++ b/FCDR_HIRS/analysis/inspect_hirs_matchups.py
@@ -194,7 +194,8 @@ def main():
     p = parse_cmdline()
     common.set_logger(
         logging.DEBUG if p.verbose else logging.INFO,
-        p.log)
+        p.log,
+        loggers={"FCDR_HIRS", "typhon"})
     hmi = HIRSMatchupInspector(
         datetime.datetime.strptime(p.from_date, p.datefmt),
         datetime.datetime.strptime(p.to_date, p.datefmt),

--- a/FCDR_HIRS/analysis/inspect_orbit_curuc.py
+++ b/FCDR_HIRS/analysis/inspect_orbit_curuc.py
@@ -269,7 +269,8 @@ def plot_compare_correlation_scanline(ds):
 
 def main():
     p = parse_cmdline()
-    set_logger(logging.DEBUG if p.verbose else logging.INFO)
+    set_logger(logging.DEBUG if p.verbose else logging.INFO,
+        loggers={"FCDR_HIRS", "typhon"})
     plot_curuc_for_pixels(
         xarray.open_dataset(p.path),
         lines=p.lines,

--- a/FCDR_HIRS/analysis/map.py
+++ b/FCDR_HIRS/analysis/map.py
@@ -106,7 +106,8 @@ def main():
     p = parse_cmdline()
     common.set_logger(
         logging.DEBUG if p.verbose else logging.INFO,
-        p.log)
+        p.log,
+        loggers={"FCDR_HIRS", "typhon"})
 
     start_time = datetime.datetime.strptime(p.start_time,
         "%Y-%m-%dT%H:%M")

--- a/FCDR_HIRS/analysis/map_single_orbit.py
+++ b/FCDR_HIRS/analysis/map_single_orbit.py
@@ -383,7 +383,8 @@ def main():
     p = parse_cmdline()
     common.set_logger(
         logging.DEBUG if p.verbose else logging.INFO,
-        p.log)
+        p.log,
+        loggers={"FCDR_HIRS", "typhon"})
 
     op = OrbitPlotter(p.arg1, p.channels, range=p.range,
         plot_bitmasks=p.with_bitmasks,

--- a/FCDR_HIRS/analysis/monitor_fcdr.py
+++ b/FCDR_HIRS/analysis/monitor_fcdr.py
@@ -293,5 +293,6 @@ def main():
     p = parse_cmdline()
     common.set_logger(
         logging.DEBUG if p.verbose else logging.INFO,
-        p.log)
+        p.log,
+        loggers={"FCDR_HIRS", "typhon"})
     plot(p)

--- a/FCDR_HIRS/analysis/plot_flags.py
+++ b/FCDR_HIRS/analysis/plot_flags.py
@@ -86,7 +86,8 @@ def main():
     p = parse_cmdline()
     common.set_logger(
         logging.DEBUG if p.verbose else logging.INFO,
-        p.log)
+        p.log,
+        loggers={"FCDR_HIRS", "typhon"})
         
     sat = p.satname
     start = datetime.datetime.strptime(p.from_date, p.datefmt)

--- a/FCDR_HIRS/analysis/summarise_fcdr.py
+++ b/FCDR_HIRS/analysis/summarise_fcdr.py
@@ -479,7 +479,8 @@ def summarise():
     p = parse_cmdline()
     common.set_logger(
         logging.DEBUG if p.verbose else logging.INFO,
-        filename=p.log)
+        filename=p.log,
+        loggers={"FCDR_HIRS", "typhon"})
 #    if p.mode != "summarise":
 #        raise NotImplementedError("Only summarising implemented yet")
     summary = FCDRSummary(satname=p.satname, data_version=p.version)

--- a/FCDR_HIRS/analysis/test_rself.py
+++ b/FCDR_HIRS/analysis/test_rself.py
@@ -148,7 +148,8 @@ def main():
     p = parse_cmdline()
     common.set_logger(
         logging.DEBUG if p.verbose else logging.INFO,
-        p.log)
+        p.log,
+        loggers={"FCDR_HIRS", "typhon"})
 #    warnings.filterwarnings("error")
 #    warnings.filterwarnings("always", category=DeprecationWarning)
     from_date = datetime.datetime.strptime(p.from_date, p.datefmt)

--- a/FCDR_HIRS/analysis/timeseries.py
+++ b/FCDR_HIRS/analysis/timeseries.py
@@ -1369,7 +1369,8 @@ def main():
     p = parse_cmdline()
     common.set_logger(
         logging.DEBUG if p.verbose else logging.INFO
-        filename=p.log)
+        filename=p.log,
+        loggers={"FCDR_HIRS", "typhon"})
         
     if p.plot_iwt_anomaly:
         write_timeseries_per_day_iwt_anomaly_period(

--- a/FCDR_HIRS/common.py
+++ b/FCDR_HIRS/common.py
@@ -161,7 +161,8 @@ def set_logger(level, filename=None, loggers=None):
     global _root_logger_set
     if loggers is None:
         loggers = {logging.getLogger(__name__).parent}
-    loggers = {logging.getLogger(s) if isinstance(s, str) else s}
+    loggers = {logging.getLogger(s) if isinstance(s, str) else s
+                for s in loggers}
     if filename:
         handler = logging.FileHandler(filename, mode="a", encoding="utf-8")
     else:

--- a/FCDR_HIRS/common.py
+++ b/FCDR_HIRS/common.py
@@ -139,8 +139,8 @@ def sample_flags(da, period="1H", dim="time"):
     return (perc, da.flag_meanings.split())
 
 
-_root_logger_set = False
-def set_logger(level, filename=None, root=True):
+_loggers_set = set()
+def set_logger(level, filename=None, loggers=None):
     """Set propertios of FIDUCEO root logger
 
     Arguments:
@@ -153,25 +153,23 @@ def set_logger(level, filename=None, root=True):
 
             What file to log to.  None for sys.stderr.
 
-        root
+        loggers
 
-            Use root logger (True), so that it applies to modules outside
-            FCDR_HIRS, or only apply it to FCDR_HIRS logging (False)
+            What loggers to set.  Default only sets the "FCDR_HIRS"
+            logger, but you may want to set others like "typhon".
     """
     global _root_logger_set
-    if root:
-        if _root_logger_set:
-            warnings.warn("Root logger already configured")
-            return
-        logger = logging.getLogger()
-        _root_logger_set = True
-    else:
-        logger = logging.getLogger(__name__).parent # should be FCDR_HIRS
+    if loggers is None:
+        loggers = {logging.getLogger(__name__).parent}
     if filename:
         handler = logging.FileHandler(filename, mode="a", encoding="utf-8")
     else:
         handler = logging.StreamHandler(sys.stderr)
-    logger.setLevel(level)
     handler.setFormatter(
         logging.Formatter("%(levelname)-8s %(name)s %(asctime)s %(module)s.%(funcName)s:%(lineno)s: %(message)s"))
-    logger.addHandler(handler)
+    for logger in loggers:
+        if logger in loggers_set:
+            warnings.warn(f"Logger {logger!s} already configured")
+            continue
+        logger.setLevel(level)
+        logger.addHandler(handler)

--- a/FCDR_HIRS/common.py
+++ b/FCDR_HIRS/common.py
@@ -161,6 +161,7 @@ def set_logger(level, filename=None, loggers=None):
     global _root_logger_set
     if loggers is None:
         loggers = {logging.getLogger(__name__).parent}
+    loggers = {logging.getLogger(s) if isinstance(s, str) else s}
     if filename:
         handler = logging.FileHandler(filename, mode="a", encoding="utf-8")
     else:

--- a/FCDR_HIRS/common.py
+++ b/FCDR_HIRS/common.py
@@ -168,7 +168,7 @@ def set_logger(level, filename=None, loggers=None):
     handler.setFormatter(
         logging.Formatter("%(levelname)-8s %(name)s %(asctime)s %(module)s.%(funcName)s:%(lineno)s: %(message)s"))
     for logger in loggers:
-        if logger in loggers_set:
+        if logger in _loggers_set:
             warnings.warn(f"Logger {logger!s} already configured")
             continue
         logger.setLevel(level)

--- a/FCDR_HIRS/processing/combine_matchups.py
+++ b/FCDR_HIRS/processing/combine_matchups.py
@@ -711,7 +711,8 @@ def combine_hirs():
     p = parse_cmdline_hirs()
     common.set_logger(
         logging.DEBUG if p.verbose else logging.INFO,
-        p.log)
+        p.log,
+        loggers={"FCDR_HIRS", "typhon"})
     warnings.filterwarnings("error",
         message="iteration over an xarray.Dataset will change",
         category=FutureWarning)
@@ -772,7 +773,8 @@ def combine_iasi():
     p = parse_cmdline_iasi()
     common.set_logger(
         logging.DEBUG if p.verbose else logging.INFO,
-        p.log)
+        p.log,
+        loggers={"FCDR_HIRS", "typhon"})
     warnings.filterwarnings("error",
         message="iteration over an xarray.Dataset will change",
         category=FutureWarning)
@@ -909,7 +911,8 @@ def merge_files():
     p = parse_cmdline_merge()
     common.set_logger(
         logging.DEBUG if p.verbose else logging.INFO,
-        p.log)
+        p.log,
+        loggers={"FCDR_HIRS", "typhon"})
     logger.info(f"Merging {len(p.files):d} files")
     new = merge_all(*p.files)
     logger.info(f"Writing to {p.out:s}")

--- a/FCDR_HIRS/processing/generate_fcdr.py
+++ b/FCDR_HIRS/processing/generate_fcdr.py
@@ -947,7 +947,8 @@ def main():
 
     common.set_logger(
         logging.DEBUG if p.verbose else logging.INFO,
-        p.log)
+        p.log,
+        loggers={"FCDR_HIRS", "typhon"})
 
     if p.days == 0:
         fgen = FCDRGenerator(p.satname,


### PR DESCRIPTION
Rather than adding everything to the root logger, we will only add to the FCDR_HIRS and typhon loggers, such that a `--verbose` flag on the various scripts does not lead to floods from `matplotlib`s own logging.