### PR TITLE
Remove pyatmlab dependency

### DIFF
--- a/FCDR_HIRS/analysis/calibcounts_stats_per_scanpos.py
+++ b/FCDR_HIRS/analysis/calibcounts_stats_per_scanpos.py
@@ -28,9 +28,9 @@ import matplotlib.ticker
 
 import typhon.plots
 matplotlib.pyplot.style.use(typhon.plots.styles("typhon"))
-import pyatmlab.graphics
 
 from .. import fcdr
+from .. import graphics
 
 logger = logging.getLogger(__name__)
 
@@ -146,7 +146,7 @@ def plot_calibcount_stats(h, Mall, channels,
     f.suptitle(title, y=1.02)
     f.subplots_adjust(hspace=0.5, wspace=0.5,
         right=0.75 if nrow*ncol==len(channels) else 0.9)
-    pyatmlab.graphics.print_or_show(f, False, filename)
+    graphics.print_or_show(f, False, filename)
 
 def plot_calibcount_anomaly_examples(h, M, channels, N,
         mode="random", typ="space", anomaly=True):
@@ -234,7 +234,7 @@ def plot_calibcount_anomaly_examples(h, M, channels, N,
     f.suptitle("{:s} {:s} view calibration {:s}".format(
         h.satname, typ, "anomalies" if anomaly else "values"))
 
-    pyatmlab.graphics.print_or_show(f, False,
+    graphics.print_or_show(f, False,
         "{:s}_{:s}_calib_{:s}_{:s}-{:%Y%m%d%H%M%S}-{:%Y%m%d%H%M%S}_{:d}_{:s}_{:s}.".format(
             typ, mode, "anomalies" if anomaly else "values", h.satname,
             M["time"][idx[0]].astype(datetime.datetime),

--- a/FCDR_HIRS/analysis/convert_hirs_l1b_to_nc.py
+++ b/FCDR_HIRS/analysis/convert_hirs_l1b_to_nc.py
@@ -24,11 +24,6 @@ import progressbar
 import typhon.datasets.dataset
 from typhon.datasets import filters
 
-import pyatmlab.stats
-import pyatmlab.config
-import pyatmlab.graphics
-import pyatmlab.tools
-
 from .. import common
 from .. import fcdr
 
@@ -50,7 +45,7 @@ def parse_cmdline():
     p = parser.parse_args()
     return p
 
-outdir = pathlib.Path(pyatmlab.config.conf["main"]["fiddatadir"],
+outdir = pathlib.Path(typhon.config.conf["main"]["fiddatadir"],
     "HIRS_L1C_NC", "{sat:s}", "{year:04d}", "{month:02d}", "{day:02d}")
 
 def convert_granule(h, satname, dt, gran, orbit_filters, overwrite=False):
@@ -203,7 +198,7 @@ def convert_period(h, sat, start_date, end_date, **kwargs):
         filters.HIRSFlagger(h, max_flagged=0.5),
             )
     bar = progressbar.ProgressBar(maxval=1,
-        widgets=pyatmlab.tools.my_pb_widget)
+        widgets=common.my_pb_widget)
     bar.start()
     bar.update(0)
     for of in orbit_filters:

--- a/FCDR_HIRS/analysis/corrmat_info_content.py
+++ b/FCDR_HIRS/analysis/corrmat_info_content.py
@@ -28,7 +28,7 @@ import typhon.arts.xml
 import typhon.atmosphere
 import typhon.config
 
-import pyatmlab.graphics
+from .. import graphics
 
 hirs_simul_dir = pathlib.Path(typhon.config.conf["main"]["simuldir"]) / "hirs"
 jacob_dir = hirs_simul_dir / "Jacobians"
@@ -234,7 +234,7 @@ def plot_dofs_hists():
 
     f.suptitle("DOFS implication (MetOpA 2016-03-02)")
 
-    pyatmlab.graphics.print_or_show(f, False, "DOFS.")
+    graphics.print_or_show(f, False, "DOFS.")
 #    print("Actual:",
 #          "DOFS", dofs(S_a, K_all, S_ε),
 #          "DOFN", dofn(S_a, K_all, S_ε))
@@ -315,7 +315,7 @@ def plot_S_degradation():
 
     f.suptitle("What is the error covariance from use of the wrong "
                "observation error covariance?")
-    pyatmlab.graphics.print_or_show(f, False, "S_degr.")
+    graphics.print_or_show(f, False, "S_degr.")
 
 def main():
     plot_S_degradation()

--- a/FCDR_HIRS/analysis/fieldmat.py
+++ b/FCDR_HIRS/analysis/fieldmat.py
@@ -25,13 +25,13 @@ import matplotlib.ticker
 import matplotlib.gridspec
 import typhon.plots
 import typhon.plots.plots
-import pyatmlab.graphics
 
 from typhon.physics.units.common import ureg
 from .. import fcdr
 from typhon.datasets import tovs
 from typhon.datasets.dataset import DataFileError
 from .. import cached
+from .. import graphics
 
 logger = logging.getLogger(__name__)
 
@@ -139,7 +139,7 @@ def plot_field_matrix(MM, ranges, title, filename, units):
                 matplotlib.ticker.MaxNLocator(nbins=4, prune="both"))
     f.suptitle(title)
     f.subplots_adjust(hspace=0.5, wspace=0.5)
-    pyatmlab.graphics.print_or_show(f, False, filename)
+    graphics.print_or_show(f, False, filename)
 
 #
 class _SatPlotHelper(metaclass=abc.ABCMeta):
@@ -211,13 +211,13 @@ class _SatPlotChCorrmat(_SatPlotHelper):
 
     def finalise(self, mp, f, gs, sat=None, solo=False):
         if solo:
-            pyatmlab.graphics.print_or_show(f, False,
+            graphics.print_or_show(f, False,
                 f"hirs_noise_correlations_sat{sat:s}_pos{self.calibpos:d}.")
         else:
             gs.update(wspace=0.10, hspace=0.4)
             f.suptitle("HIRS noise correlations for all HIRS, pos "
                       f"{self.calibpos:d} ", fontsize=40)
-            pyatmlab.graphics.print_or_show(f, False,
+            graphics.print_or_show(f, False,
                 f"hirs_noise_correlations_allsats_pos{self.calibpos:d}.")
 
 class _SatPlotFFT(_SatPlotHelper):
@@ -379,16 +379,16 @@ class _SatPlotFFT(_SatPlotHelper):
     def finalise(self, mp, f, gs, channel=None, sat=None, solo=False,
                  custom=False):
         if custom:
-            pyatmlab.graphics.print_or_show(f, False,
+            graphics.print_or_show(f, False,
                 f"hirs_crosstalk_fft_custom.")
         elif solo:
-            pyatmlab.graphics.print_or_show(f, False,
+            graphics.print_or_show(f, False,
                 f"hirs_crosstalk_fft_sat{sat:s}_ch{channel:d}.")
         else:
             gs.update(wspace=0.10, hspace=0.4)
             f.subplots_adjust(right=0.8, bottom=0.2, top=0.90)
             f.suptitle(f"Spectral analysis, channel {channel:d}")
-            pyatmlab.graphics.print_or_show(f, False,
+            graphics.print_or_show(f, False,
                 f"hirs_crosstalk_fft_ch{channel:d}.")
 
 class _SatPlotAll(_SatPlotChCorrmat, _SatPlotFFT):
@@ -575,7 +575,7 @@ class MatrixPlotter:
         f.suptitle("HIRS noise correlations, {:s}, {:s} pos {:d}\n"
             "({:d} cycles)".format(
             self.title_sat_date, noise_typ, calibpos, no))
-        pyatmlab.graphics.print_or_show(f, False,
+        graphics.print_or_show(f, False,
                 "hirs_noise_correlations_channels_{:s}_ch_{:s}_{:s}{:d}.".format(
             self.filename_sat_date,
             ",".join(str(ch) for ch in channels),
@@ -683,7 +683,7 @@ class MatrixPlotter:
                     self.title_sat_date, noise_typ, ch, no))
             ax_all[2].set_visible(False)
             ax_all[5].set_visible(False)
-            pyatmlab.graphics.print_or_show(f, False,
+            graphics.print_or_show(f, False,
                 "hirs_noise_correlations_scanpos_{:s}_ch{:d}_{:s}.png".format(
                     self.filename_sat_date, ch, noise_typ))
 
@@ -714,7 +714,7 @@ class MatrixPlotter:
 
         f.subplots_adjust(left=0.3, bottom=0.3)
 
-        pyatmlab.graphics.print_or_show(f, False,
+        graphics.print_or_show(f, False,
             f"hirs_temperature_correlation_{self.filename_sat_date:s}.png")
 
 
@@ -900,7 +900,7 @@ class MatrixPlotter:
         gs.update(wspace=0.10, hspace=0.4)
         f.suptitle("HIRS noise correlations for all HIRS, pos "
                   f"{calibpos:d} ", fontsize=40)
-        pyatmlab.graphics.print_or_show(f, False,
+        graphics.print_or_show(f, False,
             f"hirs_noise_correlations_allsats_pos{calibpos:d}.")
 
     def plot_pos_corrmat_all_sats(self, noise_typ):
@@ -990,14 +990,14 @@ class MatrixPlotter:
         for (ch, f) in f_perch.items():
             f.suptitle(f"HIRS noise correlations for all HIRS, ch. {ch:d}",
                        fontsize=40)
-            pyatmlab.graphics.print_or_show(f, False,
+            graphics.print_or_show(f, False,
                 f"hirs_noise_correlations_allsats_{noise_typ:s}_ch{ch:d}.")
         for (sat, f) in f_persat.items():
 
             f.suptitle(f"HIRS noise correlations for {sat:s}, all chans, {noise_typ:s} views\n"
                        f"{period_pairs[sat][0][0]:%Y-%m} / {period_pairs[sat][1][0]:%Y-%m}",
                         fontsize=40)
-            pyatmlab.graphics.print_or_show(f, False,
+            graphics.print_or_show(f, False,
                 f"hirs_noise_correlations_allchan_{sat:s}.")
 #            im = self._plot_ch_corrmat(S_tot, ax, channels,
 #                add_x=r==3, add_y=c==0)

--- a/FCDR_HIRS/analysis/hirs_iasi_srf_estimation.py
+++ b/FCDR_HIRS/analysis/hirs_iasi_srf_estimation.py
@@ -39,7 +39,6 @@ import typhon.datasets.tovs
 import pyatmlab.io
 import typhon.config
 import pyatmlab.physics
-import pyatmlab.graphics
 import pyatmlab.db
 
 from typhon.constants import (micro, centi, tera, nano)
@@ -48,6 +47,7 @@ from typhon.physics.units import ureg, radiance_units as rad_u
 from .. import fcdr
 from .. import math as fhmath
 from .. import common
+from .. import graphics
 
 hirs_iasi_matchup = pathlib.Path("/group_workspaces/cems2/fiduceo/Data/Matchup_Data/IASI_HIRS")
 
@@ -484,7 +484,7 @@ class LUTAnalysis:
             a.set_ylim(*scipy.stats.scoreatpercentile(y, [0.3, 99.7]))
             box = a.get_position()
             a.set_position([box.x0, box.y0, box.width * 0.85, box.height])
-            pyatmlab.graphics.print_or_show(f, False,
+            graphics.print_or_show(f, False,
                     "BT_range_LUT_ch{:d}.".format(i+1))
             matplotlib.pyplot.close(f)
 
@@ -540,7 +540,7 @@ class LUTAnalysis:
         logger.info("Using LUT to find IASI for {:,} HIRS spectra".format(radiances.size))
         if self.dobar:
             bar = progressbar.ProgressBar(maxval=radiances.size,
-                    widgets=pyatmlab.tools.my_pb_widget)
+                    widgets=common.my_pb_widget)
             bar.start()
             bar.update(0)
         for (i, dat) in enumerate(radiances):
@@ -695,18 +695,18 @@ class LUTAnalysis:
             f.suptitle("LUT PCA performance, bins {:s}".format(
                 "-".join([str(b.size) for b in self.lut.bins])))
             f.tight_layout(rect=[0, 0, 0.83, 0.97])
-        pyatmlab.graphics.print_or_show(f_tothist, False,
+        graphics.print_or_show(f_tothist, False,
             "lut_{:s}_test_hists_{:s}.".format(sat, 
                 self.lut.compact_summary().replace(".", "_")))
-        pyatmlab.graphics.print_or_show(f_deltahistperbin, False,
+        graphics.print_or_show(f_deltahistperbin, False,
             "lut_{:s}_test_deltahistperbin_{:s}.".format(sat,
                 self.lut.compact_summary().replace(".", "_")))
-        pyatmlab.graphics.print_or_show(f_bthistperbin, False,
+        graphics.print_or_show(f_bthistperbin, False,
             "lut_{:s}_test_bthistperbin_{:s}.".format(sat,
                 self.lut.compact_summary().replace(".", "_")))
         for f in {f_tothist, f_errperbin, f_deltahistperbin, f_bthistperbin}:
             matplotlib.pyplot.close(f)
-#        pyatmlab.graphics.print_or_show(f_errperbin, False,
+#        graphics.print_or_show(f_errperbin, False,
 #            "lut_{:s}_test_errperbin_{:s}.".format(sat, self.lut.compact_summary()))
         return (biases, stds)
         
@@ -770,7 +770,7 @@ class LUTAnalysis:
             for (f, lb) in zip((f1, f2), ("ch1-7", "ch8-12")):
                 f.suptitle("Mean and s.d. of $\Delta K$ for different binnings")
                 f.tight_layout(rect=[0, 0, 0.85, 0.97])
-                pyatmlab.graphics.print_or_show(f, False,
+                graphics.print_or_show(f, False,
                     "lut_{:s}_{!s}_test_perf_all_{:s}.".format(sat, 
                         ",".join(str(x) for x in channels), lb))
                 matplotlib.pyplot.close(f)
@@ -1132,7 +1132,7 @@ class IASI_HIRS_analyser(LUTAnalysis):
 #        a.bar(hirs_centres, Tb_chans[self.choice[0], self.choice[1], :], width=2e11, color="red", edgecolor="black",
 #              align="center")
 
-        pyatmlab.graphics.print_or_show(f, False,
+        graphics.print_or_show(f, False,
             "iasi_with_hirs_srf_{:s}_{:s}_{:s}.".format(sat, x_quantity, y_unit))
 
     @staticmethod
@@ -1332,7 +1332,7 @@ class IASI_HIRS_analyser(LUTAnalysis):
             x_hi = freq_hi.to(self.x["unit"][x_quantity], "sp")
             a.set_xlim(min(x_lo, x_hi).m, max(x_lo, x_hi).m)
             a2.set_xlim(min(x_lo, x_hi).m, max(x_lo, x_hi).m)
-            pyatmlab.graphics.print_or_show(f, False,
+            graphics.print_or_show(f, False,
                     "iasi_with_hirs_srfs_ch{:d}_{:s}_{:s}.".format(
                         ch, x_quantity, y_unit))
 
@@ -1365,7 +1365,7 @@ class IASI_HIRS_analyser(LUTAnalysis):
         box = a.get_position()
         a.set_position([box.x0, box.y0, box.width * 0.7, box.height])
         a.legend(loc='center left', bbox_to_anchor=(1.01, 0.5))
-        pyatmlab.graphics.print_or_show(fig, False,
+        graphics.print_or_show(fig, False,
                 "BT_Te_corrections_{:s}.".format(sat))
 
     def plot_channel_BT_deviation(self, sat):
@@ -1395,7 +1395,7 @@ class IASI_HIRS_analyser(LUTAnalysis):
             ax.set_position([box.x0, box.y0, box.width * 0.7, box.height])
             ax.set_ylabel("Delta T [K]")
         fig.subplots_adjust(hspace=0)
-        pyatmlab.graphics.print_or_show(fig, False,
+        graphics.print_or_show(fig, False,
                 "BT_channel_approximation_{:s}.".format(sat))
 
 
@@ -1431,7 +1431,7 @@ class IASI_HIRS_analyser(LUTAnalysis):
 
         if self.dobar:
             bar = progressbar.ProgressBar(maxval=len(shift),
-                    widgets=pyatmlab.tools.my_pb_widget)
+                    widgets=common.my_pb_widget)
             bar.start()
 
         logger.info("Shifting {:,} spectra by {:d} values between "
@@ -1487,7 +1487,7 @@ class IASI_HIRS_analyser(LUTAnalysis):
         a.set_xlabel("BT [K]")
         a.set_ylabel(r"$\Delta$ BT [K]")
         a.grid(axis="both")
-        pyatmlab.graphics.print_or_show(f, False,
+        graphics.print_or_show(f, False,
             "srf_shifted_dbt_hist_per_radiance_HIRS_{:s}-{:d}.".format(satellite, channel))
 
         (f, a) = matplotlib.pyplot.subplots()
@@ -1498,7 +1498,7 @@ class IASI_HIRS_analyser(LUTAnalysis):
         a.set_xlabel(r"shift [nm]")
         a.set_ylabel(r"$\Delta$ BT [K]")
         a.grid(axis="both")
-        pyatmlab.graphics.print_or_show(f, False,
+        graphics.print_or_show(f, False,
             "srf_shifted_dbt_hist_per_shift_HIRS_{:s}-{:d}.".format(satellite, channel))
 
     def _prepare_map(self):
@@ -1567,7 +1567,7 @@ class IASI_HIRS_analyser(LUTAnalysis):
         a.set_title("{satname:s} hirs-{ch:d}, iasi-simulated or real\n"
                      "{dt1:%y-%m-%d %h:%m} -- {dt2:%H:%M}".format(
                         satname=satname, ch=c, dt1=dt1, dt2=dt2))
-        pyatmlab.graphics.print_or_show(f, False,
+        graphics.print_or_show(f, False,
             "map_BTHIRS_real_simul_ch{:d}_{:%Y%m%d%H%M%S}.".format(c,dt1))
 
     def map_with_hirs_pca(self, h, satname, cmap="viridis"):
@@ -1598,7 +1598,7 @@ class IASI_HIRS_analyser(LUTAnalysis):
         cb = f.colorbar(c)
         cb.set_label("Weight")
         a.set_title("PCA weight matrix HIRS measured {:%Y-%m-%d %H:%M:%S}".format(dt1))
-        pyatmlab.graphics.print_or_show(f, False,
+        graphics.print_or_show(f, False,
             "PCA_weight_HIRS_measured_{:%Y%m%d%H%M%S}.".format(dt1))
 
         (f, a) = matplotlib.pyplot.subplots(1)
@@ -1606,7 +1606,7 @@ class IASI_HIRS_analyser(LUTAnalysis):
         cb = f.colorbar(c)
         cb.set_label("Weight")
         a.set_title("PCA weight matrix IASI-simulated HIRS {:%Y-%m-%d %H:%M:%S}".format(dt1))
-        pyatmlab.graphics.print_or_show(f, False,
+        graphics.print_or_show(f, False,
             "PCA_weight_HIRS_IASI_simul_{:%Y%m%d%H%M%S}.".format(dt1))
 
         (f, a) = matplotlib.pyplot.subplots(1)
@@ -1614,7 +1614,7 @@ class IASI_HIRS_analyser(LUTAnalysis):
         cb = f.colorbar(c)
         cb.set_label("Weight")
         a.set_title("PCA weight matrix IASI-meas-simulated HIRS {:%Y-%m-%d %H:%M:%S}".format(dt1))
-        pyatmlab.graphics.print_or_show(f, False,
+        graphics.print_or_show(f, False,
             "PCA_weight_HIRS_IASI_delta_meas_simul_{:%Y%m%d%H%M%S}.".format(dt1))
         
         for i in range(12):
@@ -1638,7 +1638,7 @@ class IASI_HIRS_analyser(LUTAnalysis):
             a.set_title("{satname:s} HIRS PC {pc:d}, iasi-simulated or real PC scores\n"
                          "{dt1:%Y-%m-%d %H:%M} -- {dt2:%H:%M}".format(
                             satname=satname, pc=i, dt1=dt1, dt2=dt2))
-            pyatmlab.graphics.print_or_show(f, False,
+            graphics.print_or_show(f, False,
                 "map_BTHIRS_real_simul_pc{:d}_{:%Y%m%d%H%M%S}.".format(i+1,dt1))
 
     
@@ -1749,7 +1749,7 @@ class IASI_HIRS_analyser(LUTAnalysis):
         f.tight_layout()
         f.subplots_adjust(top=0.88, right=0.88)
 
-        pyatmlab.graphics.print_or_show(f, False,
+        graphics.print_or_show(f, False,
                 "iasi_with_hirs_srfs_all_Tb_{sat_ref:s}_{sat_targ:s}_{ch:s}_{sh:s}.".format(
                     sat_ref=sat_ref, sat_targ=sat_targ,
                     ch=",".join([str(x) for x in chans]),
@@ -1773,7 +1773,7 @@ class IASI_HIRS_analyser(LUTAnalysis):
         self._plot_dtb_hist(dtb, ax_all)
         f.suptitle(r"Expected $\Delta$BT {:s} - {:s}".format(sat_targ, sat_ref))
         f.subplots_adjust(hspace=0.25)
-        pyatmlab.graphics.print_or_show(f, False,
+        graphics.print_or_show(f, False,
             "expected_Tdiff_{:s}-{:s}.".format(sat_targ, sat_ref))
 
     def plot_hist_pls_perf(self, sat_ref, sat_targ, tb_ref, tb_targ):
@@ -1784,7 +1784,7 @@ class IASI_HIRS_analyser(LUTAnalysis):
         self._plot_dtb_hist(dtb, ax_all)
         f.suptitle(r"PLS performance $\Delta$BT, predicting {:s} from {:s}".format(sat_targ, sat_ref))
         f.subplots_adjust(hspace=0.25)
-        pyatmlab.graphics.print_or_show(f, False,
+        graphics.print_or_show(f, False,
             "PLS_performance_Tdiff_{:s}-{:s}.".format(sat_targ, sat_ref))
 
     def plot_fragment_expected_Tdiff(self, sat_ref, sat_targ,
@@ -1825,10 +1825,10 @@ class IASI_HIRS_analyser(LUTAnalysis):
             a.set_xlabel("Channel no.")
             a.set_ylabel("Measurement no.")
 
-        pyatmlab.graphics.print_or_show(f_ref, False,
+        graphics.print_or_show(f_ref, False,
             "slice_TB_{:s}.".format(sat_ref))
 
-        pyatmlab.graphics.print_or_show(f_diff, False,
+        graphics.print_or_show(f_diff, False,
             "slice_TB_diff_{:s}_{:s}{:+.2f}.".format(sat_targ, sat_ref, 
                 srfshift.to(ureg.um, "sp").m))
 
@@ -2329,9 +2329,9 @@ class IASI_HIRS_analyser(LUTAnalysis):
                 noise_quantity=noise_quantity,
                 noise_units=noise_units)
             
-        pyatmlab.graphics.print_or_show(f1, False,
+        graphics.print_or_show(f1, False,
             "srf_estimate_errdist_per_localmin_"+fn_lab)
-        pyatmlab.graphics.print_or_show(f2, False,
+        graphics.print_or_show(f2, False,
             "srf_misestimate_bt_propagation_"+fn_lab)
             
 
@@ -2413,7 +2413,7 @@ class IASI_HIRS_analyser(LUTAnalysis):
                    cost_mode, predict_quantity, noise_quantity,
                    noise_units))
         f.subplots_adjust(hspace=0.47, wspace=0.35)#, right=0.7)
-        pyatmlab.graphics.print_or_show(f, False,
+        graphics.print_or_show(f, False,
             "SRF_prediction_cost_function_{sat:s}_{sat2:s}_{db:s}_{ref:s}_"
             "{regression_type.__name__:s}_{regrargs:s}_lim{limstr:s}_A{A:d}"
             "_B{B:d}_noise{noise_targ:d},{noise_lev:d}_cm{cm:s}_{cst:s}_"
@@ -2499,7 +2499,7 @@ class IASI_HIRS_analyser(LUTAnalysis):
 
         if self.dobar:
             bar = progressbar.ProgressBar(maxval=estimates.size,
-                    widgets=pyatmlab.tools.my_pb_widget)
+                    widgets=common.my_pb_widget)
             bar.start()
 
         for i in range(estimates.size):
@@ -2580,7 +2580,7 @@ class IASI_HIRS_analyser(LUTAnalysis):
 
         with tofile.with_suffix(".info").open("a", encoding="utf-8") as fp:
             fp.write(" ".join(sys.argv) + "\n")
-            fp.write(pyatmlab.tools.get_verbose_stack_description())
+            fp.write(common.get_verbose_stack_description())
 
         with tofile.with_suffix(".dat").open("a", encoding="ascii") as fp:
             fp.write(
@@ -2656,7 +2656,7 @@ class IASI_HIRS_analyser(LUTAnalysis):
         a.set_xlabel("IASI-simulated HIRS [{:~}]".format(iasi_rad.u))
         a.set_ylabel("HIRS - IASI-simulated HIRS [{:~}]".format(iasi_rad.u))
         a.set_title("IASI-HIRS comparison {:s}".format(ds.RefStartTimeSec))
-        pyatmlab.graphics.print_or_show(f, False,
+        graphics.print_or_show(f, False,
             "HIRS_IASI_comparison_{:s}.".format(ds.RefStartTimeSec))
 
 
@@ -2695,7 +2695,7 @@ class IASI_HIRS_analyser(LUTAnalysis):
             a.legend(loc="upper left")
             cb = f.colorbar(c)
             cb.set_label("No. spectra")
-            pyatmlab.graphics.print_or_show(f, False,
+            graphics.print_or_show(f, False,
                 "HIRS_{:d}_exp_radrange_{:s}.".format(ch, lab))
 
 def main():

--- a/FCDR_HIRS/analysis/inspect_hirs_harm_matchups.py
+++ b/FCDR_HIRS/analysis/inspect_hirs_harm_matchups.py
@@ -16,8 +16,6 @@ import matplotlib.pyplot
 import xarray
 import scipy.stats
 
-import pyatmlab.graphics
-
 from typhon.physics.units.tools import UnitsAwareDataArray as UADA
 from typhon.physics.units.common import radiance_units as rad_u
 import typhon.physics.units.em
@@ -26,6 +24,7 @@ import typhon.config
 from .. import matchups
 from .. import fcdr
 from .. import common
+from .. import graphics
 
 logger = logging.getLogger(__name__)
 def parse_cmdline():
@@ -394,7 +393,7 @@ def plot_ds_summary_stats(ds, lab="", Ldb=None, write=False):
         ", ".join(str(c) for c in numpy.atleast_1d(ds[f"K_{lab:s}forward"].attrs["channels_prediction"])))
     f.subplots_adjust(hspace=0.35, wspace=0.3)
 
-    pyatmlab.graphics.print_or_show(f, False,
+    graphics.print_or_show(f, False,
         "harmstats/{sensor_1_name:s}_{sensor_2_name:s}/ch{channel:d}/harmonisation_K_stats_{sensor_1_name:s}-{sensor_2_name:s}_ch{channel:d}_{time_coverage:s}_{lab:s}.".format(
             channel=ds["channel"].item(), lab=lab, **ds.attrs))
     
@@ -421,7 +420,7 @@ def plot_harm_input_stats(ds):
             a.set_ylabel("Count")
     f.suptitle("harm input stats for pair {sensor_1_name:s}, {sensor_2_name:s}, {time_coverage:s}, with med+N*mad away".format(**ds.attrs)
         + ", channel " + str(ds["channel"].item()))
-    pyatmlab.graphics.print_or_show(f, False,
+    graphics.print_or_show(f, False,
         "harmstats/{sensor_1_name:s}_{sensor_2_name:s}/ch{channel:d}/harmonisation_input_stats_{sensor_1_name:s}-{sensor_2_name:s}_ch{channel:d}_{time_coverage:s}_.".format(
             channel=ds["channel"].item(), **ds.attrs))
 

--- a/FCDR_HIRS/analysis/inspect_hirs_matchups.py
+++ b/FCDR_HIRS/analysis/inspect_hirs_matchups.py
@@ -21,13 +21,12 @@ import netCDF4
 import scipy.stats
 
 import typhon.plots
-import pyatmlab.graphics
 import matplotlib.ticker
 
 from typhon.physics.units import radiance_units as rad_u
 from typhon.datasets.tovs import HIRSHIRS
 
-from .. import (fcdr, matchups, common)
+from .. import (fcdr, matchups, common, graphics)
 matplotlib.pyplot.style.use(typhon.plots.styles("typhon"))
 logger = logging.getLogger(__name__)
 
@@ -184,7 +183,7 @@ class HIRSMatchupInspector(matchups.HIRSMatchupCombiner):
             self.M["time"][0].astype(datetime.datetime),
             self.M["time"][-1].astype(datetime.datetime)))
 
-        pyatmlab.graphics.print_or_show(f, False,
+        graphics.print_or_show(f, False,
             "hirshirs/hirshirs_{:s}_{:s}_{:%Y%m%d%H%M}_{:%Y%m%d%H%M}_ch{:d}.png".format(
                 prim, sec,
                 self.M["time"][0].astype(datetime.datetime),

--- a/FCDR_HIRS/analysis/inspect_orbit_curuc.py
+++ b/FCDR_HIRS/analysis/inspect_orbit_curuc.py
@@ -21,11 +21,10 @@ import typhon.datasets.tovs
 from typhon.physics.units.common import radiance_units as rad_u, ureg
 from typhon.physics.units.tools import UnitsAwareDataArray as UADA   
 
-import pyatmlab.graphics
-
 from ..processing.generate_fcdr import FCDRGenerator
 from ..common import (set_logger, add_to_argparse)
 from .. import metrology
+from .. import graphics
 
 def parse_cmdline():
     parser = argparse.ArgumentParser(
@@ -103,8 +102,9 @@ def plot_curuc_for_pixels(ds, lines, channel, x_all, y_all):
         robust=True, return_vectors=True, interpolate_lengths=True,
         sampling_l=1, sampling_e=1, return_locals=True)
 
-    del sensRe # this causes pyatmlabs get_verbose_stack_description to
-               # fail as pprint.pprint can't sort Relational objects
+    del sensRe # this causes get_verbose_stack_description to
+               # fail as pprint.pprint can't sort Relational objects,
+               # perhaps replacing pickle by dill will help
 
     # get centroid
     srf = fg.fcdr.srfs[channel-1]
@@ -120,7 +120,7 @@ def plot_curuc_for_pixels(ds, lines, channel, x_all, y_all):
     a.set_ylabel("mean correlation coefficient")
     a.set_title("Cross-element error correlation function "
                 + shared_tit + "\n" + period_tit)
-    pyatmlab.graphics.print_or_show(f, False,
+    graphics.print_or_show(f, False,
         "curuc/cross_element_error_correlation_function_"+shared_fn+".")
 
     # cross-line error correlation function
@@ -130,7 +130,7 @@ def plot_curuc_for_pixels(ds, lines, channel, x_all, y_all):
     a.set_ylabel("mean correlation coefficient")
     a.set_title("Cross-line error correlation function "
                 + shared_tit + "\n" + period_tit)
-    pyatmlab.graphics.print_or_show(f, False,
+    graphics.print_or_show(f, False,
         "curuc/cross_line_error_correlation_function_"+shared_fn+".")
 
     cmap = "magma_r"
@@ -156,7 +156,7 @@ def plot_curuc_for_pixels(ds, lines, channel, x_all, y_all):
 #            + "\n"
 #            + scnlinlab)
         a.set_aspect("equal")
-        pyatmlab.graphics.print_or_show(f, False,
+        graphics.print_or_show(f, False,
             "curuc/cross_element_S" + shared_fn +
             f"x{x:d}y{y:d}.")
 
@@ -177,7 +177,7 @@ def plot_curuc_for_pixels(ds, lines, channel, x_all, y_all):
 #            + shared_tit
 #            + f"element {x:d}")
         a.set_aspect("equal")
-        pyatmlab.graphics.print_or_show(f, False,
+        graphics.print_or_show(f, False,
             "curuc/cross_line_S" + shared_fn +
             f"_x{x:d}y{y:d}.")
 
@@ -203,7 +203,7 @@ def plot_curuc_for_pixels(ds, lines, channel, x_all, y_all):
         a.set_xticklabels([str(x.item()) for x in ds["channel"]])
         a.set_yticks(numpy.arange(ds.dims["channel"]))
         a.set_yticklabels([str(x.item()) for x in ds["channel"]])
-        pyatmlab.graphics.print_or_show(f, False,
+        graphics.print_or_show(f, False,
             "curuc/cross_channel_S" + shared_fn +
             f"_x{x:d}y{y:d}.")
 
@@ -224,7 +224,7 @@ def plot_curuc_for_pixels(ds, lines, channel, x_all, y_all):
         a.set_xticklabels([str(x.item()) for x in ds["channel"]])
         a.set_yticks(numpy.arange(ds.dims["channel"]))
         a.set_yticklabels([str(x.item()) for x in ds["channel"]])
-        pyatmlab.graphics.print_or_show(f, False,
+        graphics.print_or_show(f, False,
             "curuc/cross_channel_R_correlated_noise_" + shared_fn +
             f".")
 
@@ -244,7 +244,7 @@ def plot_curuc_for_pixels(ds, lines, channel, x_all, y_all):
         a.set_xticklabels([str(x.item()) for x in ds["channel"]])
         a.set_yticks(numpy.arange(ds.dims["channel"]))
         a.set_yticklabels([str(x.item()) for x in ds["channel"]])
-        pyatmlab.graphics.print_or_show(f, False,
+        graphics.print_or_show(f, False,
             "curuc/cross_channel_S_correlated_noise_" + shared_fn +
             f".")
 
@@ -265,7 +265,7 @@ def plot_compare_correlation_scanline(ds):
     a.set_ylabel("Mean correlation coefficient")
     a.set_title("Mean correlation as function of scanline interval, single orbit")
 
-    pyatmlab.graphics.print_or_show(f, False, "orbit_curuc_test.")
+    graphics.print_or_show(f, False, "orbit_curuc_test.")
 
 def main():
     p = parse_cmdline()

--- a/FCDR_HIRS/analysis/map.py
+++ b/FCDR_HIRS/analysis/map.py
@@ -11,9 +11,9 @@ import datetime
 import matplotlib.pyplot
 import mpl_toolkits.basemap
 
-import pyatmlab.graphics
 from .. import fcdr
 from .. import common
+from .. import graphics
 
 logger = logging.getLogger(__name__)
 def parse_cmdline():
@@ -58,13 +58,13 @@ def plot_field(lon, lat, fld, filename, tit, cblabel, **kwargs):
     (f, a) = matplotlib.pyplot.subplots(figsize=(14, 8))
     m = mpl_toolkits.basemap.Basemap(projection="moll", resolution="c",
         lon_0=0, ax=a)
-    c = pyatmlab.graphics.pcolor_on_map(
+    c = graphics.pcolor_on_map(
         m, lon, lat, fld, cmap="viridis", **kwargs)
     m.drawcoastlines()
     cb = m.colorbar(c)
     cb.set_label(cblabel)
     a.set_title(tit)
-    pyatmlab.graphics.print_or_show(
+    graphics.print_or_show(
         f, False, filename)
 
 def read_and_plot_field(satname, field, start_time, duration, channels=[],

--- a/FCDR_HIRS/analysis/map_single_orbit.py
+++ b/FCDR_HIRS/analysis/map_single_orbit.py
@@ -38,8 +38,7 @@ import typhon.plots.plots
 from .. import math as fcm
 from .. import common
 from . import inspect_orbit_curuc
-
-import pyatmlab.graphics
+from .. import graphics
 
 logger = logging.getLogger(__name__)
 
@@ -126,7 +125,7 @@ class OrbitPlotter:
             self.selections[ch] = self.plot_channel(
                 ch, ax_all[ch], cax_all[ch],
                 mark_pixels=mark_pixels)
-#        pyatmlab.graphics.print_or_show(
+#        graphics.print_or_show(
 #            f, False, filename)
 
     def prepare_figure_and_axes(self, channels):
@@ -371,7 +370,7 @@ class OrbitPlotter:
 
     def write(self):
         p = self.path.absolute()
-        pyatmlab.graphics.print_or_show(
+        graphics.print_or_show(
             self.fig, False,
             "orbitplots/"
             + str((p.relative_to(p.parents[3]).parent / p.stem))

--- a/FCDR_HIRS/analysis/monitor_fcdr.py
+++ b/FCDR_HIRS/analysis/monitor_fcdr.py
@@ -19,10 +19,10 @@ import numpy
 
 from typhon.physics.units.common import ureg, radiance_units as rad_u
 from typhon.physics.units.tools import UnitsAwareDataArray as UADA
-import pyatmlab.graphics
 from .. import fcdr
 from .. import _fcdr_defs
 from .. import common
+from .. import graphics
 
 # NB: https://github.com/pydata/xarray/issues/1661#issuecomment-339525582
 from pandas.tseries import converter
@@ -224,7 +224,7 @@ class FCDRMonitor:
         fig.suptitle(self.figtit.format(tb=tb, te=te,
             self=self, ch=ch, sp=sp))
 
-        pyatmlab.graphics.print_or_show(fig, False,
+        graphics.print_or_show(fig, False,
             self.figname.format(tb=tb, te=te, self=self, ch=ch))
 
     def _plot_var_with_unc(self, da, da_rand, da_nonrand, a, a_h, a_u, a_u_h):

--- a/FCDR_HIRS/analysis/plot_flags.py
+++ b/FCDR_HIRS/analysis/plot_flags.py
@@ -15,8 +15,8 @@ import xarray
 import numpy
 import matplotlib.pyplot
 import typhon.datasets.tovs
-import pyatmlab.graphics
 import typhon.datasets.filters
+from .. import graphics
 
 logger = logging.getLogger(__name__)
 def parse_cmdline():
@@ -78,7 +78,7 @@ def plot(sat, start, end):
     a.grid(axis="x")
     #f.subplots_adjust(left=0.2)
 
-    pyatmlab.graphics.print_or_show(f, False,
+    graphics.print_or_show(f, False,
         "hirs_flags/{sat:s}_{start:%Y}/hirs_flags_set_{sat:s}_{start:%Y%m%d%H%M}-{end:%Y%m%d%H%M}.png".format(
             sat=sat, start=start, end=end))
 

--- a/FCDR_HIRS/analysis/summarise_fcdr.py
+++ b/FCDR_HIRS/analysis/summarise_fcdr.py
@@ -25,7 +25,7 @@ from typhon.datasets.dataset import (DataFileError, HomemadeDataset)
 from typhon.physics.units.common import ureg, radiance_units as rad_u
 from typhon.physics.units.tools import UnitsAwareDataArray as UADA
 from typhon.datasets.tovs import norm_tovs_name
-import pyatmlab.graphics
+from .. import graphics
 from .. import fcdr
 
 logger = logging.getLogger(__name__)
@@ -405,7 +405,7 @@ class FCDRSummary(HomemadeDataset):
             del summary
         for channel in range(1, 20):
             (f, a_all) = figs[channel]
-            pyatmlab.graphics.print_or_show(f, None, 
+            graphics.print_or_show(f, None, 
                 self.plot_file.format(satname=satlabel, start=start,
                 end=end, channel=channel, data_version=self.data_version,
                 ptilestr=','.join(str(p) for p in ptiles)))
@@ -416,7 +416,7 @@ class FCDRSummary(HomemadeDataset):
                 lo = ranges.loc[{"channel": channel, "field": fld, "extremum": "lo"}].min()
                 hi = ranges.loc[{"channel": channel, "field": fld, "extremum": "hi"}].max()
                 a.set_ylim([lo, hi])
-            pyatmlab.graphics.print_or_show(f, None, 
+            graphics.print_or_show(f, None, 
                 self.plot_file.format(satname=satlabel, start=start,
                     end=end, channel=channel,
                     data_version=self.data_version,
@@ -471,7 +471,7 @@ class FCDRSummary(HomemadeDataset):
             a.set_xlabel("Brightness temperature uncertainty [K]")
             a.set_ylabel("Total number of pixels")
         f.suptitle(tit)
-        pyatmlab.graphics.print_or_show(f, None, 
+        graphics.print_or_show(f, None, 
             self.plot_hist_file.format(satname=self.satname, start=start,
             end=end, data_version=self.data_version))
 

--- a/FCDR_HIRS/analysis/test_rself.py
+++ b/FCDR_HIRS/analysis/test_rself.py
@@ -18,13 +18,13 @@ import matplotlib.ticker
 import scipy.stats
 import datetime
 import typhon.plots
-import pyatmlab.graphics
 
 from typhon.physics.units.common import ureg, radiance_units as rad_u
 
 from .. import models
 from .. import fcdr
 from .. import common
+from .. import graphics
 
 logger = logging.getLogger(__name__)
 
@@ -112,7 +112,7 @@ def plot_rself_test(h, ds, temperatures, channels,
 
     f.suptitle(tit)
     f.subplots_adjust(hspace=0.3)
-    pyatmlab.graphics.print_or_show(f, False, fn)
+    graphics.print_or_show(f, False, fn)
 
 
 def read_and_plot_rself_test(sat, from_date, to_date, temperatures,

--- a/FCDR_HIRS/analysis/timeseries.py
+++ b/FCDR_HIRS/analysis/timeseries.py
@@ -55,14 +55,9 @@ import typhon.math.stats
 import typhon.datasets.dataset
 from typhon.physics.units.common import ureg
 
-import pyatmlab.stats
-#import pyatmlab.config
-import pyatmlab.graphics
-#import pyatmlab.datasets.tovs
-#from pyatmlab.units import ureg
-
 from .. import common
 from .. import fcdr
+from .. import graphics
 
 srcfile_temp_iwt = pathlib.Path(typhon.config.conf["main"]["myscratchdir"],
                        "hirs_{sat:s}_{year:d}_temp_iwt.npz")
@@ -245,7 +240,7 @@ def plot_timeseries_temp_iwt_anomaly(sat, nrow=4):
     ax_all[-1].set_xlabel("Date")
     f.suptitle("IWT PRT orbit-averaged anomalies, {:s}".format(sat))
     f.subplots_adjust(hspace=0.25)
-    pyatmlab.graphics.print_or_show(f, False,
+    graphics.print_or_show(f, False,
         "timeseries_{:s}_temp_iwp.".format(sat))
 
 def extract_timeseries_per_day_iwt_anomaly_period(sat, start_date, end_date):
@@ -263,7 +258,7 @@ def extract_timeseries_per_day_iwt_anomaly_period(sat, start_date, end_date):
 
     # Binning doesn't work with a time-axis.  Convert to float, but be
     # sure that float relates to the same time-format first
-    binned = pyatmlab.stats.bin(dts.astype("M8[s]").astype("f8"),
+    binned = typhon.math.stats.bin(dts.astype("M8[s]").astype("f8"),
                                 anomalies,
                                 bins.astype("M8[s]").astype("f8"))
 
@@ -466,7 +461,7 @@ class NoiseAnalyser:
         f.suptitle("Space counts Allan deviation {:s} HIRS {:%Y-%m-%d}--{:%Y-%m-%d}".format(
             self.satname, t[0], t[-1]))
         f.subplots_adjust(hspace=0.25)
-        pyatmlab.graphics.print_or_show(f, False,
+        graphics.print_or_show(f, False,
             "hirs_{:s}_space_counts_adev_{:%Y%m%d}-{:%Y%m%d}.".format(
                 self.satname, t[0], t[-1])
                 + "" if self.writefig else "png")
@@ -512,12 +507,6 @@ class NoiseAnalyser:
 #        ch = self.ch
         start_date = self.start_date
         end_date = self.end_date
-        # need SRF for calculating gain
-#        hconf = pyatmlab.config.conf["hirs"]
-#        (centres, srfs) = pyatmlab.io.read_arts_srf(
-#            hconf["srf_backend_f"].format(sat=self.satname.upper().replace("NOAA0","NOAA")),
-#            hconf["srf_backend_response"].format(sat=self.satname.upper().replace("NOAA0","NOAA")))
-#        srf = pyatmlab.physics.SRF(*srfs[ch-1])
 
         # cycle manually as I plot many at once
         styles = list(matplotlib.pyplot.style.library["typhon"]["axes.prop_cycle"])
@@ -608,7 +597,7 @@ class NoiseAnalyser:
         # For some reason, sometimes it still fails to use the LaTeX
         # cache.  Make sure we create it /again/ ?!
         pathlib.Path("/dev/shm/gerrit/cache").mkdir(parents=True, exist_ok=True)
-        pyatmlab.graphics.print_or_show(self.fig, False,
+        graphics.print_or_show(self.fig, False,
             "hirs_noise/{self.satname:s}_{tb:%Y}/ch{ch:d}/disect_{self.satname:s}_hrs_ch{ch:d}_{alltyp:s}_{alltemp:s}_{tb:%Y%m%d%H%M}-{te:%Y%m%d%H%M}{corrinfo:s}.".format(
                 self=self, ch=ch, alltyp='_'.join(all_tp),
                 alltemp='_'.join(temperatures), tb=t[0], te=t[-1],
@@ -1315,7 +1304,7 @@ class NoiseAnalyser:
                    "{:%Y-%m-%d}--{:%Y-%m-%d} pos {:d}".format(
                         self.satname, self.start_date, self.end_date,
                         calibpos))
-        pyatmlab.graphics.print_or_show(f, False,
+        graphics.print_or_show(f, False,
             "timeseries_channel_noise_correlation_"
             "HIRS_{:s}{:%Y%m%d%H%M}-{:%Y%m%d%H%M}_p{:d}.".format(
                 self.satname, self.start_date, self.end_date, scanpos)

--- a/FCDR_HIRS/common.py
+++ b/FCDR_HIRS/common.py
@@ -13,6 +13,7 @@ import pprint
 import inspect
 import numpy
 import xarray
+import progressbar
 from .fcdr import list_all_satellites
 
 my_pb_widget = [progressbar.Bar("=", "[", "]"), " ",

--- a/FCDR_HIRS/common.py
+++ b/FCDR_HIRS/common.py
@@ -7,9 +7,18 @@ import sys
 import logging
 import datetime
 import warnings
+import traceback
+import io
+import pprint
+import inspect
 import numpy
 import xarray
 from .fcdr import list_all_satellites
+
+my_pb_widget = [progressbar.Bar("=", "[", "]"), " ",
+                progressbar.Percentage(), " (",
+                progressbar.AdaptiveETA(), " -> ",
+                progressbar.AbsoluteETA(), ') ']
 
 def add_to_argparse(parser,
         include_period=True,
@@ -175,3 +184,47 @@ def set_logger(level, filename=None, root=True):
     handler.setFormatter(
         logging.Formatter("%(levelname)-8s %(name)s %(asctime)s %(module)s.%(funcName)s:%(lineno)s: %(message)s"))
     logger.addHandler(handler)
+
+
+def get_verbose_stack_description(first=2, last=-1, include_source=True,
+                                    include_locals=True, include_globals=False):
+    f = io.StringIO()
+    f.write("".join(traceback.format_stack()))
+    for fminfo in inspect.stack()[first:last]:
+        frame = fminfo.frame
+        try:
+            f.write("-" * 60 + "\n")
+            if include_source:
+                try:
+                    f.write(inspect.getsource(frame) + "\n")
+                except OSError:
+                    f.write(str(inspect.getframeinfo(frame)) + 
+                         "\n(no source code)\n")
+            if include_locals:
+                f.write(pprint.pformat(frame.f_locals) + "\n")
+            if include_globals:
+                f.write(pprint.pformat(frame.f_globals) + "\n")
+        finally:
+            try:
+                frame.clear()
+            except RuntimeError:
+                pass
+    return f.getvalue()
+
+def savetxt_3d(fname, data, *args, **kwargs):
+    """Write 3D-array to file that pgfplots likes
+    """
+    with open(fname, 'wb') as outfile:
+        for data_slice in data:
+            numpy.savetxt(outfile, data_slice, *args, **kwargs)
+            outfile.write(b"\n")
+
+def plotdatadir():
+    """Returns todays plotdatadir
+
+    Configuration 'plotdatadir' must be set.  Value is expanded with
+    strftime.
+    """
+    return datetime.date.today().strftime(
+        config.conf["main"]["plotdatadir"])
+

--- a/FCDR_HIRS/fcdr.py
+++ b/FCDR_HIRS/fcdr.py
@@ -29,14 +29,13 @@ from typhon.physics.units.common import ureg, radiance_units as rad_u
 from typhon.datasets.tovs import (Radiometer, HIRS, HIRSPOD, HIRS2,
     HIRSKLM, HIRS3, HIRS4)
 
-from pyatmlab import tools
-
 from . import models
 from . import effects
 from . import measurement_equation as me
 from . import filters
 from . import _fcdr_defs
 from . import _harm_defs
+from . import common
 from .exceptions import (FCDRError, FCDRWarning) # used to be here
 
 logger = logging.getLogger(__name__)
@@ -1777,7 +1776,7 @@ class HIRSFCDR(typhon.datasets.dataset.HomemadeDataset):
 
                 Channel to calibrate.
 
-            srf [pyatmlab.physics.SRF]
+            srf [typhon.physics.units.em.SRF]
 
                 SRF to use for calibrating the channel and converting
                 radiances to units of BT.  Optional; if None, use
@@ -1815,7 +1814,7 @@ class HIRSFCDR(typhon.datasets.dataset.HomemadeDataset):
             "{:,} radiances".format(realisations,
                rad_wn.size))
         bar = progressbar.ProgressBar(maxval=realisations,
-                widgets = tools.my_pb_widget)
+                widgets = common.my_pb_widget)
         bar.start()
         for i in range(realisations):
             with ureg.context("radiance"):

--- a/FCDR_HIRS/math.py
+++ b/FCDR_HIRS/math.py
@@ -54,7 +54,7 @@ def calc_y_for_srf_shift(Δλ, y_master, srf0, L_spectral_db, f_spectra, y_ref,
             data, and y_ref would be the same for training data.  In the
             real world, y_ref is still simulated, but y_master are actual
             measurements.
-        srf0 (`:func:pyatmlab.physics.SRF`): SRF relative to which
+        srf0 (`:func:typhon.physics.units.em.SRF`): SRF relative to which
             the shift is to be calculated.
         L_spectral_db (ndarray M×l): Database of spectra (such as from IASI)
             to use.  Should be in spectral radiance per frequency units [W
@@ -213,7 +213,7 @@ def calc_cost_for_srf_shift(Δλ, y_master, y_target, srf0,
             comes from either the testing data (calculated by shifting
             srf0 by an amount you haven't told me, but I mean to recover),
             or from actual measurements.
-        srf0 (`:func:pyatmlab.physics.SRF`): SRF corresponding to
+        srf0 (`:func:typhon.physics.units.em.SRF`): SRF corresponding to
             zero shift, relative to which the shift is estimated.
         L_spectral_db (ndarray N×p): Database of spectra (such as from IASI)
             to use.  Should be in SI spectral radiance per frequency units [W
@@ -285,7 +285,7 @@ def estimate_srf_shift(y_master, y_target, srf0, L_spectral_db, f_spectra,
             Unit must be consistent with what you tell me in
             predict_quantity.
         y_target (ndarray): Radiances or BTs for other satellite
-        srf0 (`:func:pyatmlab.physics.SRF`): SRF for reference satellite
+        srf0 (`:func:typhon.physics.em.units.SRF`): SRF for reference satellite
         L_spectral_db (ndarray N×p): Database of spectra (such as from IASI)
             to use.  Should ALWAYS be in spectral radiance per frequency
             units, regardless of what predict_quantity is.

--- a/setup.py
+++ b/setup.py
@@ -95,7 +95,6 @@ setup(
                       "matplotlib>=2.0",
                       "numexpr>=2.6",
                       "typhon>=0.5.0",
-                      "pyatmlab>=0.1.2",
                       "progressbar2>=3.10",
                       "netCDF4>=1.2",
                       "pandas>=0.21",


### PR DESCRIPTION
This PR removes the pyatmlab dependency by moving `print_or_show` and some other functionality and definitions from `pyatmlab`.  The only remaining `pyatmlab` dependency is in the `hirs_iasi_srf_estimation` script which currently probably doesn`t work anyway as it`s old and hasn't been properly integrated into `FCDR_HIRS` yet.