### PR TITLE
Give up if no space views in data to be calibrated

### DIFF
--- a/FCDR_HIRS/fcdr.py
+++ b/FCDR_HIRS/fcdr.py
@@ -397,6 +397,10 @@ class HIRSFCDR(typhon.datasets.dataset.HomemadeDataset):
 
         (counts_space, counts_iwct) = self.extract_calibcounts(context,
             ch, fail_if_none=True)
+        
+        # let's also trigger a failure if the context does but the core
+        # does not have calibration counts
+        self.extract_calibcounts(ds, ch, fail_if_none=True)
 
         if counts_space["time"].size == 0:
             # set slices that will make things empty


### PR DESCRIPTION
Give up if no space views in data to be calibrated, even if space views
are available in the context.  The alternative would be to expand the data
to be calibrated with context data, but I don't currently have enough
bookkeeping to do so.